### PR TITLE
Fix trusted publishing authentication

### DIFF
--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -94,8 +94,15 @@ jobs:
           git tag "v${VERSION}"
           git push origin main --follow-tags
 
+      - name: Authenticate with crates.io
+        if: steps.release_gate.outputs.should_release == 'true'
+        id: crates_io_auth
+        uses: rust-lang/crates-io-auth-action@v1
+
       - name: Publish crate
         if: steps.release_gate.outputs.should_release == 'true'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates_io_auth.outputs.token }}
         run: cargo publish --locked
 
       - name: Create GitHub release

--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -87,8 +87,15 @@ jobs:
           git tag "v${VERSION}"
           git push origin main --follow-tags
 
+      - name: Authenticate with crates.io
+        if: steps.release_gate.outputs.should_release == 'true'
+        id: crates_io_auth
+        uses: rust-lang/crates-io-auth-action@v1
+
       - name: Publish crate
         if: steps.release_gate.outputs.should_release == 'true'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates_io_auth.outputs.token }}
         run: cargo publish --locked
 
       - name: Create GitHub release

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ successful steps only.
 
 Repository configuration still matters:
 
-- crates.io Trusted Publishing is supported by the release workflows through GitHub OIDC, so `CRATES_IO_TOKEN` is not required when Trusted Publishing is configured for this repository and workflow.
+- crates.io Trusted Publishing is supported by the release workflows through GitHub OIDC plus `rust-lang/crates-io-auth-action`, so `CRATES_IO_TOKEN` is not required when Trusted Publishing is configured for this repository and workflow.
 - If branch protection blocks workflow pushes to `main`, add a `RELEASE_GITHUB_TOKEN` secret for a token that is allowed to push the automated release commit and tag.
 - Branch protection is configured to require the `Validate PR Policy` and `Rust Checks` status checks before merge.
 


### PR DESCRIPTION
## Summary
- authenticate release workflows with crates.io via `rust-lang/crates-io-auth-action@v1`
- pass the temporary crates.io token into `cargo publish --locked`
- document the trusted publishing flow in the README

## Issue
Closes #5

## Testing
- workflow logic change only
- publish failure reproduced from merged release workflow logs
