### PR TITLE
Fix release tag publishing

### DIFF
--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -91,8 +91,8 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add Cargo.toml Cargo.lock
           git commit -m "chore: release v${VERSION} [skip release]"
-          git tag "v${VERSION}"
-          git push origin main --follow-tags
+          git tag -a "v${VERSION}" -m "v${VERSION}"
+          git push origin main "v${VERSION}"
 
       - name: Authenticate with crates.io
         if: steps.release_gate.outputs.should_release == 'true'

--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -84,8 +84,8 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add Cargo.toml Cargo.lock
           git commit -m "chore: release v${VERSION} [skip release]"
-          git tag "v${VERSION}"
-          git push origin main --follow-tags
+          git tag -a "v${VERSION}" -m "v${VERSION}"
+          git push origin main "v${VERSION}"
 
       - name: Authenticate with crates.io
         if: steps.release_gate.outputs.should_release == 'true'


### PR DESCRIPTION
## Summary
- create annotated release tags in the patch and manual release workflows
- push the release tag explicitly instead of relying on `--follow-tags`
- fix GitHub release creation after merge

## Issue
Closes #7

## Testing
- workflow logic change only
- failure reproduced from merged release workflow logs
