### PR TITLE
feat: add provider system prompt fragments

### DIFF
--- a/openspec/changes/add-provider-system-prompt-fragments/.openspec.yaml
+++ b/openspec/changes/add-provider-system-prompt-fragments/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/add-provider-system-prompt-fragments/design.md
+++ b/openspec/changes/add-provider-system-prompt-fragments/design.md
@@ -1,0 +1,118 @@
+## Context
+
+Issue `#11` asks for provider-specific system prompt fragments that `iron-core` can inject into its system prompt. The useful contract is a small raw Markdown fragment per provider family. The original issue text described separate `iron-provider-*` crates, but this repository is a single crate with two relevant public boundaries:
+
+- Provider modules, such as `src/openai.rs` and `src/anthropic.rs`.
+- `ProviderProfile` plus `ProviderRegistry`, which select provider behavior by `ApiFamily` and registered slug.
+
+Current `ApiFamily` variants are `OpenAiResponses`, `OpenAiChatCompletions`, and `AnthropicMessages`. Current default registry slugs include `anthropic`, `minimax`, `minimax-code`, `zai`, `zai-code`, `kimi`, `kimi-code`, `openrouter`, and `requesty`. OpenAI is supported and used today through the concrete `OpenAiProvider` path, but `openai` is not a default registry slug.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Expose provider-specific Markdown prompt fragments as `&'static str`.
+- Keep fragments safe for caller-side templating by excluding Tera delimiters such as `{{`, `{%`, and `{#`.
+- Map all currently supported `ApiFamily` variants to an appropriate fragment.
+- Let `iron-core` retrieve fragments through either the concrete OpenAI/Anthropic module path or the registry/profile path.
+- Keep the implementation additive and simple.
+
+**Non-Goals:**
+
+- Adding new provider integrations or profiles.
+- Adding `openai` to `ProviderRegistry::default()` as part of this change.
+- Creating separate provider crates.
+- Introducing runtime template rendering in `iron-providers`.
+- Maintaining separate fragments for future provider families until they exist in this crate.
+
+## Decisions
+
+### 1. Store fragments as Markdown files included at compile time
+
+Add Markdown files under `src/system_prompt_fragments/` and include them with `include_str!`. The public API should return `&'static str` directly.
+
+Why this decision:
+
+- Markdown files are easier to review and edit than embedded Rust string literals.
+- `include_str!` keeps the API allocation-free and avoids runtime I/O.
+- Raw Markdown is compatible with `iron-core` injecting the fragment via a safe template filter.
+
+Alternative considered: generate fragments dynamically from profile metadata.
+
+- Rejected because these fragments are guidance text, not data derived mechanically from profile fields.
+
+### 2. Provide module-level helpers for existing provider APIs
+
+Add `SYSTEM_PROMPT_FRAGMENT` constants and `system_prompt_fragment()` helpers to `anthropic` and `openai` modules.
+
+Why this decision:
+
+- It matches how OpenAI is supported today: through the concrete `OpenAiProvider` path rather than a default registry slug.
+- It gives direct provider users a simple API without needing to construct a profile or registry.
+- It keeps the public API discoverable next to each provider implementation.
+
+Alternative considered: expose only a central `system_prompt` module.
+
+- Rejected because the issue asks for provider-level access, and module-level helpers are the most direct equivalent in the single-crate architecture.
+
+### 3. Map profile fragments by `ApiFamily`
+
+Add `ProviderProfile::system_prompt_fragment(&self) -> &'static str` and route by `self.family`:
+
+- `ApiFamily::AnthropicMessages` uses the Anthropic-style fragment.
+- `ApiFamily::OpenAiResponses` uses the OpenAI-compatible fragment.
+- `ApiFamily::OpenAiChatCompletions` uses the OpenAI-compatible fragment.
+
+Why this decision:
+
+- The registry profiles already encode the provider protocol family that determines prompt-shaping constraints.
+- All current built-ins can resolve without adding provider-specific branches for each slug.
+- OpenAI-compatible providers share the relevant JSON schema and tool-calling guidance at this layer.
+
+Alternative considered: map by provider slug.
+
+- Rejected for this change because it would duplicate the existing family model and make compatible provider additions more error-prone.
+
+### 4. Add registry lookup without changing registered providers
+
+Add `ProviderRegistry::system_prompt_fragment(&self, provider_name: &str) -> ProviderResult<&'static str>` using the same case-insensitive lookup semantics as `ProviderRegistry::get`.
+
+Why this decision:
+
+- `iron-core` can resolve prompt guidance from the same configured provider name it uses to obtain providers.
+- Unknown providers can reuse the crate's existing `ProviderError` pattern.
+- This does not require changing the default registry contents.
+
+Alternative considered: make unknown providers fall back to OpenAI guidance.
+
+- Rejected because fallback would hide configuration mistakes and could inject the wrong provider instructions.
+
+### 5. Keep fragment validation lightweight and local
+
+Tests should assert that fragments are non-empty, contain no Tera delimiters, and that every default registry slug resolves to a non-empty fragment. Tests should also cover module helpers and explicit `ApiFamily` mapping.
+
+Why this decision:
+
+- It directly protects the integration contract with `iron-core`.
+- It avoids adding Markdown parsers or template engines to this crate for a simple static-text feature.
+
+Alternative considered: parse Markdown in tests.
+
+- Rejected because CommonMark validity is not the main risk here; unsafe template delimiters and missing mappings are.
+
+## Risks / Trade-offs
+
+- OpenAI-compatible providers may eventually need more specific fragments. Mitigation: start with family-level mapping now and add slug- or profile-specific overrides only when a concrete behavior difference appears.
+- Fragment wording can become stale as provider APIs evolve. Mitigation: keep fragments concise, provider-family oriented, and covered by tests that ensure every current family has a mapping.
+- Adding public helpers in provider modules slightly expands the crate surface. Mitigation: the API is additive, simple, and returns static text without new runtime behavior.
+- `ProviderRegistry::system_prompt_fragment` will not resolve `openai` unless callers registered an OpenAI profile. Mitigation: direct OpenAI users can call `openai::system_prompt_fragment()`, and adding an OpenAI registry slug remains out of scope unless a separate requirement appears.
+
+## Migration Plan
+
+This is an additive feature. Existing callers do not need to change. `iron-core` can adopt the new API by calling the module helper for its existing concrete OpenAI path or the registry/profile helper when working with registered providers.
+
+Rollback is straightforward because the change adds static files and public helper methods without altering inference behavior.
+
+## Open Questions
+
+- Should future provider-specific overrides be modeled as an optional `ProviderProfile` field or as internal slug-specific matching? This change intentionally avoids deciding until a provider-specific fragment is actually needed.

--- a/openspec/changes/add-provider-system-prompt-fragments/proposal.md
+++ b/openspec/changes/add-provider-system-prompt-fragments/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`iron-core` needs provider-specific system prompt guidance that can be injected into its higher-level prompt templates without hard-coding provider behavior outside this crate. The original issue assumed one crate per provider, but this repository is a single `iron-providers` crate with provider modules and registry profiles. The proposal should therefore expose fragments from the existing module and profile boundaries instead of inventing separate provider crates.
+
+OpenAI is already supported through `src/openai.rs`, `OpenAiProvider`, and `ApiFamily::OpenAiResponses`. The registry built-ins are a separate profile-driven provider-selection path and should not be changed just to satisfy this feature.
+
+## What Changes
+
+- Add raw Markdown system prompt fragments for Anthropic-style and OpenAI-compatible providers.
+- Expose module-level helpers from the existing provider modules, including `anthropic::system_prompt_fragment()` and `openai::system_prompt_fragment()`.
+- Add profile-driven fragment resolution via `ProviderProfile::system_prompt_fragment()` based on `ApiFamily`.
+- Add registry-level lookup via `ProviderRegistry::system_prompt_fragment(provider_name)` for registered profiles.
+- Add validation coverage that fragments are non-empty, concise enough for prompt injection, and contain no Tera syntax delimiters.
+
+## Capabilities
+
+### New Capabilities
+- `provider-system-prompt-fragments`: Defines how provider-specific Markdown fragments are exposed by module helpers, provider profiles, and the provider registry.
+
+### Modified Capabilities
+
+## Impact
+
+- Affected code: `src/anthropic.rs`, `src/openai.rs`, `src/profile.rs`, `src/registry.rs`, `src/lib.rs`, new prompt fragment source files, and tests.
+- Affected behavior: callers can ask this crate for provider-specific prompt guidance without duplicating provider-family knowledge in `iron-core`.
+- API impact: additive public API only. This change must not require adding an `openai` slug to `ProviderRegistry::default()`.
+- Out of scope: splitting this crate into per-provider crates, adding new provider integrations, and adding provider-specific fragments for Gemini, Azure, DeepSeek, local, or Ollama before those providers/profiles exist here.

--- a/openspec/changes/add-provider-system-prompt-fragments/specs/provider-system-prompt-fragments/spec.md
+++ b/openspec/changes/add-provider-system-prompt-fragments/specs/provider-system-prompt-fragments/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: Provider modules SHALL expose static prompt fragments
+Provider modules with direct public provider APIs SHALL expose their provider-specific system prompt guidance as raw Markdown `&'static str` values.
+
+#### Scenario: Anthropic module exposes a fragment
+- **WHEN** a caller invokes `anthropic::system_prompt_fragment()`
+- **THEN** the function returns the Anthropic system prompt fragment as a non-empty `&'static str`
+
+#### Scenario: OpenAI module exposes a fragment
+- **WHEN** a caller invokes `openai::system_prompt_fragment()`
+- **THEN** the function returns the OpenAI-compatible system prompt fragment as a non-empty `&'static str`
+
+### Requirement: Profile fragments SHALL be selected by API family
+`ProviderProfile` SHALL expose `system_prompt_fragment(&self) -> &'static str` and SHALL select the fragment from the profile's `ApiFamily`.
+
+#### Scenario: Anthropic Messages profile resolves Anthropic guidance
+- **WHEN** a `ProviderProfile` has `family` set to `ApiFamily::AnthropicMessages`
+- **THEN** `ProviderProfile::system_prompt_fragment()` returns the Anthropic system prompt fragment
+
+#### Scenario: OpenAI Responses profile resolves OpenAI-compatible guidance
+- **WHEN** a `ProviderProfile` has `family` set to `ApiFamily::OpenAiResponses`
+- **THEN** `ProviderProfile::system_prompt_fragment()` returns the OpenAI-compatible system prompt fragment
+
+#### Scenario: OpenAI Chat Completions profile resolves OpenAI-compatible guidance
+- **WHEN** a `ProviderProfile` has `family` set to `ApiFamily::OpenAiChatCompletions`
+- **THEN** `ProviderProfile::system_prompt_fragment()` returns the OpenAI-compatible system prompt fragment
+
+### Requirement: Registry lookup SHALL resolve prompt fragments for registered providers
+`ProviderRegistry` SHALL expose `system_prompt_fragment(&self, provider_name: &str) -> ProviderResult<&'static str>` and use the registered provider profile to resolve the fragment.
+
+#### Scenario: Default registry providers resolve fragments
+- **WHEN** a caller requests the system prompt fragment for any default registry slug
+- **THEN** the registry returns a non-empty fragment for that provider
+
+#### Scenario: Registry lookup is case-insensitive
+- **WHEN** a caller requests a registered provider name using different letter casing
+- **THEN** the registry returns the same fragment as the canonical lowercase slug
+
+#### Scenario: Unknown registry provider returns an error
+- **WHEN** a caller requests a system prompt fragment for a provider name that is not registered
+- **THEN** the registry returns a `ProviderError` instead of falling back to an unrelated fragment
+
+#### Scenario: OpenAI default registry membership is unchanged
+- **WHEN** the default provider registry is constructed
+- **THEN** this feature does not require `openai` to be present as a default registry slug
+
+### Requirement: Prompt fragments SHALL be safe for caller-side template injection
+Prompt fragments SHALL be raw Markdown text suitable for caller-side prompt-template injection and SHALL NOT contain Tera syntax delimiters.
+
+#### Scenario: Fragments contain no expression delimiters
+- **WHEN** tests inspect every prompt fragment shipped by this crate
+- **THEN** no fragment contains `{{`
+
+#### Scenario: Fragments contain no block delimiters
+- **WHEN** tests inspect every prompt fragment shipped by this crate
+- **THEN** no fragment contains `{%`
+
+#### Scenario: Fragments contain no comment delimiters
+- **WHEN** tests inspect every prompt fragment shipped by this crate
+- **THEN** no fragment contains `{#`
+
+#### Scenario: Fragments remain raw Markdown
+- **WHEN** a caller retrieves a prompt fragment
+- **THEN** the returned string is raw Markdown and this crate performs no template rendering

--- a/openspec/changes/add-provider-system-prompt-fragments/tasks.md
+++ b/openspec/changes/add-provider-system-prompt-fragments/tasks.md
@@ -1,0 +1,28 @@
+## 1. Fragment Content
+
+- [x] 1.1 Add `src/system_prompt_fragments/anthropic.md` with concise Anthropic Messages guidance.
+- [x] 1.2 Add `src/system_prompt_fragments/openai.md` with concise OpenAI-compatible Responses and Chat Completions guidance.
+- [x] 1.3 Ensure fragments are valid Markdown prose/bullets and contain no Tera delimiters (`{{`, `{%`, `{#`).
+
+## 2. Public API
+
+- [x] 2.1 Add `SYSTEM_PROMPT_FRAGMENT` and `system_prompt_fragment() -> &'static str` to `src/anthropic.rs`.
+- [x] 2.2 Add `SYSTEM_PROMPT_FRAGMENT` and `system_prompt_fragment() -> &'static str` to `src/openai.rs`.
+- [x] 2.3 Add `ProviderProfile::system_prompt_fragment(&self) -> &'static str` mapped by `ApiFamily`.
+- [x] 2.4 Add `ProviderRegistry::system_prompt_fragment(&self, provider_name: &str) -> ProviderResult<&'static str>` using existing case-insensitive registered-profile lookup behavior.
+- [x] 2.5 Export any new module or helper needed from `src/lib.rs` and `prelude` only if required for ergonomic public access.
+
+## 3. Tests
+
+- [x] 3.1 Add tests that `anthropic::system_prompt_fragment()` and `openai::system_prompt_fragment()` return the expected non-empty fragments.
+- [x] 3.2 Add tests that each `ApiFamily` maps to the intended fragment through `ProviderProfile::system_prompt_fragment()`.
+- [x] 3.3 Add tests that `ProviderRegistry::system_prompt_fragment()` resolves every default registry slug to a non-empty fragment.
+- [x] 3.4 Add tests that unknown registry provider names return `ProviderError`.
+- [x] 3.5 Add tests that all fragments contain no Tera delimiters.
+
+## 4. Verification
+
+- [x] 4.1 Run `cargo build --locked --all-targets`.
+- [x] 4.2 Run `cargo fmt --manifest-path Cargo.toml -- --check`.
+- [x] 4.3 Run `cargo clippy --locked --all-targets --all-features -- -D warnings`.
+- [x] 4.4 Run `cargo test --locked`.

--- a/src/anthropic.rs
+++ b/src/anthropic.rs
@@ -528,6 +528,12 @@ fn handle_error(status: reqwest::StatusCode, body: &str) -> ProviderError {
     }
 }
 
+pub const SYSTEM_PROMPT_FRAGMENT: &str = include_str!("system_prompt_fragments/anthropic.md");
+
+pub fn system_prompt_fragment() -> &'static str {
+    SYSTEM_PROMPT_FRAGMENT
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -788,5 +794,12 @@ mod tests {
         assert_eq!(tool_calls[1].call_id, "call_1");
         assert_eq!(tool_calls[1].tool_name, "search");
         assert_eq!(tool_calls[1].arguments["query"], "rust");
+    }
+
+    #[test]
+    fn test_system_prompt_fragment_is_non_empty() {
+        let fragment = system_prompt_fragment();
+        assert!(!fragment.is_empty());
+        assert_eq!(fragment, SYSTEM_PROMPT_FRAGMENT);
     }
 }

--- a/src/openai.rs
+++ b/src/openai.rs
@@ -515,9 +515,18 @@ pub async fn infer_stream(
     Ok(TerminatingStream::new(events).boxed())
 }
 
+pub const SYSTEM_PROMPT_FRAGMENT: &str = include_str!("system_prompt_fragments/openai.md");
+
+pub fn system_prompt_fragment() -> &'static str {
+    SYSTEM_PROMPT_FRAGMENT
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{build_input_items, build_tool_choice, build_tools, process_stream_event};
+    use super::{
+        build_input_items, build_tool_choice, build_tools, process_stream_event,
+        system_prompt_fragment, SYSTEM_PROMPT_FRAGMENT,
+    };
     use crate::{InferenceRequest, Message, RuntimeRecord, ToolDefinition, ToolPolicy, Transcript};
     use async_openai::types::responses::{
         EasyInputContent, InputItem, ResponseStreamEvent, Tool as OpenAiTool, ToolChoiceOptions,
@@ -649,5 +658,12 @@ mod tests {
         assert!(!events
             .iter()
             .any(|event| matches!(event, crate::ProviderEvent::Complete)));
+    }
+
+    #[test]
+    fn test_system_prompt_fragment_is_non_empty() {
+        let fragment = system_prompt_fragment();
+        assert!(!fragment.is_empty());
+        assert_eq!(fragment, SYSTEM_PROMPT_FRAGMENT);
     }
 }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -102,6 +102,15 @@ impl ProviderProfile {
     pub fn models_dev_slug(&self) -> &str {
         self.models_dev_id.as_deref().unwrap_or(&self.slug)
     }
+
+    pub fn system_prompt_fragment(&self) -> &'static str {
+        match self.family {
+            ApiFamily::AnthropicMessages => crate::anthropic::SYSTEM_PROMPT_FRAGMENT,
+            ApiFamily::OpenAiResponses | ApiFamily::OpenAiChatCompletions => {
+                crate::openai::SYSTEM_PROMPT_FRAGMENT
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -84,6 +84,18 @@ impl ProviderRegistry {
         slugs
     }
 
+    pub fn system_prompt_fragment(&self, provider_name: &str) -> ProviderResult<&'static str> {
+        let key = provider_name.to_lowercase();
+        let profile = self.profiles.get(&key).ok_or_else(|| {
+            let available: Vec<&str> = self.profiles.keys().map(|s| s.as_str()).collect();
+            ProviderError::general(format!(
+                "Unknown provider '{}'. Available: {:?}",
+                provider_name, available
+            ))
+        })?;
+        Ok(profile.system_prompt_fragment())
+    }
+
     pub fn register_builtins(&mut self) {
         self.register(
             ProviderProfile::new(
@@ -323,5 +335,58 @@ mod tests {
         let mut sorted = slugs.clone();
         sorted.sort();
         assert_eq!(slugs, sorted);
+    }
+
+    #[test]
+    fn test_system_prompt_fragment_for_all_builtins() {
+        let registry = ProviderRegistry::default();
+        for slug in registry.slugs() {
+            let fragment = registry.system_prompt_fragment(slug).expect(slug);
+            assert!(
+                !fragment.is_empty(),
+                "fragment for '{}' should not be empty",
+                slug
+            );
+        }
+    }
+
+    #[test]
+    fn test_system_prompt_fragment_case_insensitive() {
+        let registry = ProviderRegistry::default();
+        let lower = registry.system_prompt_fragment("anthropic").unwrap();
+        let upper = registry.system_prompt_fragment("ANTHROPIC").unwrap();
+        assert_eq!(lower, upper);
+    }
+
+    #[test]
+    fn test_system_prompt_fragment_unknown_provider() {
+        let registry = ProviderRegistry::default();
+        let result = registry.system_prompt_fragment("nonexistent");
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert!(e.to_string().contains("Unknown provider"));
+        }
+    }
+
+    #[test]
+    fn test_fragments_contain_no_tera_delimiters() {
+        let fragments = [
+            crate::anthropic::SYSTEM_PROMPT_FRAGMENT,
+            crate::openai::SYSTEM_PROMPT_FRAGMENT,
+        ];
+        for fragment in fragments {
+            assert!(
+                !fragment.contains("{{"),
+                "fragment should not contain Tera expression delimiter"
+            );
+            assert!(
+                !fragment.contains("{%"),
+                "fragment should not contain Tera block delimiter"
+            );
+            assert!(
+                !fragment.contains("{#"),
+                "fragment should not contain Tera comment delimiter"
+            );
+        }
     }
 }

--- a/src/system_prompt_fragments/anthropic.md
+++ b/src/system_prompt_fragments/anthropic.md
@@ -1,0 +1,4 @@
+- This provider uses the Anthropic Messages API. Claude models support extended thinking and prompt caching.
+- Tools are defined with JSON schema in `input_schema` fields. Tool use appears as `tool_use` content blocks.
+- Streaming tool calls use `partial_json` deltas and must be assembled before completion.
+- Always include `max_tokens` in requests; default to a conservative value when unset.

--- a/src/system_prompt_fragments/openai.md
+++ b/src/system_prompt_fragments/openai.md
@@ -1,0 +1,4 @@
+- This provider uses the OpenAI Responses or Chat Completions API. Both accept JSON schema `tools` arrays.
+- Function tools require `type`, `name`, `description`, and `parameters` as JSON Schema.
+- Streaming tool call deltas arrive in `choices[].delta.tool_calls[]` and must be assembled by index.
+- Place system instructions in the `messages` array with role `system` for Chat Completions.


### PR DESCRIPTION
Expose provider-specific Markdown prompt fragments for Anthropic and OpenAI-compatible APIs.

What changed:
- Added src/system_prompt_fragments/anthropic.md and openai.md with concise, provider-family-specific guidance.
- Added module-level helpers anthropic::system_prompt_fragment() and openai::system_prompt_fragment().
- Added ProviderProfile::system_prompt_fragment() mapped by ApiFamily.
- Added ProviderRegistry::system_prompt_fragment() for registered slug lookup.
- Added tests verifying fragments are non-empty, registry resolves all builtins, case-insensitive lookup works, unknown providers error, and no Tera delimiters are present.

Verification:
- cargo build --locked --all-targets
- cargo fmt --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked (80 unit tests + integration tests passed)

Closes #11