### PR TITLE
feat: add provider credential abstractions and OAuth-backed providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,9 +23,9 @@ dependencies = [
 
 [[package]]
 name = "async-openai"
-version = "0.36.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78efd86812da6b76e2be727c7015522dde20495855390496099f062b01d2c868"
+checksum = "dafa6acfa9d5138539abe815de90b0a4b7127420e6846c71bb23cf68660641ba"
 dependencies = [
  "async-openai-macros",
  "backoff",
@@ -41,7 +41,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -159,12 +159,6 @@ dependencies = [
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -716,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -765,13 +759,14 @@ version = "0.1.8"
 dependencies = [
  "async-openai",
  "async-stream",
+ "base64",
  "futures",
  "mockito",
  "pin-project",
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-test",
  "tracing",
@@ -785,27 +780,32 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
@@ -839,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1064,7 +1064,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -1086,7 +1086,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1220,9 +1220,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
@@ -1284,10 +1284,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
-name = "rustls"
-version = "0.23.39"
+name = "rustc_version"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -1321,9 +1330,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
@@ -1428,6 +1437,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,6 +1502,22 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -1588,31 +1619,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -1877,9 +1888,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1890,9 +1901,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1900,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1910,9 +1921,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1923,9 +1934,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -1945,9 +1956,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2018,15 +2029,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -2050,21 +2052,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -2102,12 +2089,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2120,12 +2101,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2135,12 +2110,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2168,12 +2137,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2183,12 +2146,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2204,12 +2161,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2219,12 +2170,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ tracing = "0.1"
 futures = "0.3"
 pin-project = "1"
 reqwest = { version = "0.13", features = ["json", "stream"] }
+base64 = "0.22"
 
 # OpenAI SDK - enable features for Responses API
 async-openai = { version = "0.36", features = ["responses", "response-types", "_api"] }

--- a/README.md
+++ b/README.md
@@ -23,19 +23,21 @@ Built-in provider profiles are identified by slug. Each slug maps to a specific 
 | `zai` | `zai` | OpenAI Chat Completions | General | Bearer token |
 | `zai-code` | `zai-coding-plan` | OpenAI Chat Completions | Coding | Bearer token |
 | `kimi` | `moonshotai` | OpenAI Chat Completions | General | Bearer token |
-| `kimi-code` | `kimi-for-coding` | Anthropic Messages | Coding | `x-api-key` header |
+| `kimi-code` | `kimi-for-coding` | Anthropic Messages | Coding | `x-api-key` header or OAuth Bearer |
 | `openrouter` | `openrouter` | OpenAI Chat Completions | General | Bearer token |
 | `requesty` | `requesty` | OpenAI Chat Completions | General | Bearer token |
+| `codex` | `openai` | Codex Responses | Coding | OAuth Bearer |
 
 Coding-purpose slugs route to endpoints optimized for code generation tasks.
 
 ## API Families
 
-Providers are grouped into three adapter families:
+Providers are grouped into four adapter families:
 
 - **OpenAiResponses** — Uses the OpenAI Responses API via `async-openai`.
 - **OpenAiChatCompletions** — Uses the `/chat/completions` endpoint via `reqwest`. Compatible with any OpenAI-compatible API.
 - **AnthropicMessages** — Uses the Anthropic `/v1/messages` endpoint via `reqwest`.
+- **CodexResponses** — Uses the Codex `/responses` endpoint via `reqwest`. Supports `store: false`, `reasoning`, and `parallel_tool_calls`.
 
 ## Registry Usage
 
@@ -75,6 +77,41 @@ let runtime = RuntimeConfig::new("key")
 
 `OpenAiConfig` exposes equivalent `with_connect_timeout` /
 `with_read_timeout` builders for direct callers of `openai::infer`.
+
+## Credentials
+
+Providers accept either an API key or an OAuth bearer token via `RuntimeConfig`.
+
+**API key (default):**
+
+```rust
+use iron_providers::RuntimeConfig;
+
+let runtime = RuntimeConfig::new("your-api-key");
+```
+
+**OAuth bearer token:**
+
+```rust
+use iron_providers::{RuntimeConfig, ProviderCredential};
+use std::time::{SystemTime, Duration};
+
+let runtime = RuntimeConfig::from_credential(
+    ProviderCredential::OAuthBearer {
+        access_token: "oauth-access-token".to_string(),
+        expires_at: Some(SystemTime::now() + Duration::from_secs(3600)),
+        id_token: None,
+    }
+);
+```
+
+Each `ProviderProfile` declares which credential kinds it supports via `credential_auth`. When a credential is passed, `GenericProvider` validates:
+
+1. The credential kind is supported by the profile.
+2. OAuth bearer tokens have not expired.
+3. The underlying secret is non-empty.
+
+If validation fails, `ProviderError::auth()` is returned immediately with a clear message.
 
 ## Request Model
 
@@ -275,11 +312,9 @@ See [`MIGRATION.md`](./MIGRATION.md) for breaking API changes including:
 
 ## Dependency Notes
 
-`async-openai` was upgraded to `0.35`.
+`async-openai` was upgraded to `0.36`.
 
-The planned direct `reqwest` upgrade to `0.13` is currently deferred because
-`async-openai 0.35` still depends on `reqwest 0.12`, which would otherwise
-introduce incompatible `reqwest::Client` types into the dependency graph.
+`reqwest` was upgraded to `0.13`.
 
 ## License
 

--- a/openspec/changes/add-provider-credential-oauth/.openspec.yaml
+++ b/openspec/changes/add-provider-credential-oauth/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-03

--- a/openspec/changes/add-provider-credential-oauth/design.md
+++ b/openspec/changes/add-provider-credential-oauth/design.md
@@ -1,0 +1,310 @@
+## Context
+
+The crate currently models provider auth as:
+
+- `RuntimeConfig { api_key: String, connect_timeout, read_timeout }`
+- `ProviderProfile { auth_strategy: AuthStrategy, ... }`
+- `AuthStrategy::{BearerToken, ApiKeyHeader, Custom}`
+- `build_http_client(HttpClientParams { api_key, auth_strategy, ... })`
+
+This works for API-key-only providers, but not for providers that support multiple credential kinds with different wire headers. The clearest example is `kimi-code`:
+
+- API key uses `x-api-key: <api_key>`.
+- OAuth access token uses `Authorization: Bearer <access_token>`.
+
+The same single-string shape also blurs responsibilities. `iron-providers` should not own OAuth refresh tokens or refresh flows. It should receive a current credential snapshot from `iron-core` or the application layer and validate/use that snapshot for provider requests.
+
+Codex is the other initial target. Research from OpenAI Codex CLI and Goose shows that ChatGPT/Codex access uses `https://chatgpt.com/backend-api/codex/responses` with OAuth bearer auth. It is Responses-like, but it is not the public OpenAI Responses API and not Chat Completions. Therefore the existing `openai` provider should remain unchanged and Codex should be represented separately.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve existing API-key behavior and `RuntimeConfig::new(api_key)`.
+- Represent runtime credentials explicitly as API key or OAuth bearer.
+- Allow provider profiles to declare supported credential kinds and per-kind auth strategies.
+- Fail clearly for missing, unsupported, or expired credentials.
+- Support `kimi-code` API-key and OAuth bearer modes with different headers.
+- Add `codex` as a distinct provider with `ApiFamily::CodexResponses` and `models_dev_id = "openai"`.
+- Implement Codex exact URL, headers, and request body fields with mocked HTTP tests.
+- Extract Codex `chatgpt-account-id` routing metadata from unverified JWT payload claims when available.
+
+**Non-Goals:**
+
+- Implement OAuth login, browser/device-code/loopback flows, or refresh-token exchange.
+- Store refresh tokens or other long-lived OAuth secrets.
+- Automatically refresh and retry after `401 Unauthorized`.
+- Change the existing public `openai` provider behavior.
+- Add OAuth to general `kimi`.
+- Hard-code Codex model lists from Goose or Codex CLI.
+- Add Goose's `gpt-5.3-codex` tool preamble in this crate.
+
+## Decisions
+
+### 1. Model credential kind separately from wire auth strategy
+
+Add:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum CredentialKind {
+    ApiKey,
+    OAuthBearer,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ProviderCredential {
+    ApiKey(String),
+    OAuthBearer {
+        access_token: String,
+        expires_at: Option<SystemTime>,
+        id_token: Option<String>,
+    },
+}
+```
+
+`AuthStrategy::BearerToken` remains the wire-header strategy. It does not imply that the credential is an OAuth token; it only means "place the selected credential value in `Authorization: Bearer ...`."
+
+Why this decision:
+
+- `kimi-code` proves credential kind and wire strategy are different axes.
+- Profiles need to say which credential kinds they support.
+- Consumers need explicit credential mode selection without overloading API-key strings.
+
+### 2. Preserve API-key construction and add credential-aware construction
+
+Keep:
+
+```rust
+RuntimeConfig::new(api_key)
+```
+
+Add:
+
+```rust
+RuntimeConfig::from_credential(credential)
+```
+
+Internally, `RuntimeConfig` should store `ProviderCredential` instead of only `api_key`, while preserving timeout fields and builder methods.
+
+Implementation sketch:
+
+```rust
+pub struct RuntimeConfig {
+    pub credential: ProviderCredential,
+    pub connect_timeout: Option<Duration>,
+    pub read_timeout: Option<Duration>,
+}
+
+impl RuntimeConfig {
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self::from_credential(ProviderCredential::ApiKey(api_key.into()))
+    }
+
+    pub fn from_credential(credential: ProviderCredential) -> Self { ... }
+}
+```
+
+The old public `api_key` field cannot remain as the source of truth if the crate supports non-API-key credentials. If there is no external persistence format depending on struct field names, prefer the simpler direct field migration over compatibility scaffolding. If tests or downstream usage reveal a real compatibility need, add targeted helpers rather than duplicating secret state.
+
+### 3. Add per-credential profile auth metadata
+
+Replace or supersede the single `ProviderProfile.auth_strategy` with:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CredentialAuthConfig {
+    pub kind: CredentialKind,
+    pub auth_strategy: AuthStrategy,
+}
+
+pub struct ProviderProfile {
+    // existing fields...
+    pub credential_auth: Vec<CredentialAuthConfig>,
+}
+```
+
+Add convenience builders:
+
+```rust
+ProviderProfile::with_auth(strategy) // keep as API-key-oriented compatibility helper
+ProviderProfile::with_credential_auth(kind, strategy)
+ProviderProfile::supports_credential(kind) -> bool
+ProviderProfile::auth_strategy_for(kind) -> Option<&AuthStrategy>
+```
+
+Recommended semantics:
+
+- `ProviderProfile::new(...)` defaults to API-key bearer auth, matching today's default.
+- `with_auth(strategy)` sets or replaces the API-key auth config so existing built-in setup remains readable.
+- `with_credential_auth(kind, strategy)` adds or replaces that specific credential kind's auth config.
+
+Why this decision:
+
+- It keeps common API-key-only providers concise.
+- It supports `kimi-code` mixed headers without duplicate provider slugs.
+- It avoids treating credential mode as provider identity.
+
+### 4. Validate selected credentials early and clearly
+
+Add helper constructors or messages on `ProviderError::Authentication` for:
+
+- missing credential value
+- unsupported credential kind for provider
+- expired credential
+
+Use authentication errors, not invalid request errors, for credential problems.
+
+Validation rules:
+
+- API key must not be blank.
+- OAuth access token must not be blank.
+- OAuth `expires_at <= SystemTime::now()` fails before request execution.
+- OAuth `expires_at: None` is allowed.
+- Provider construction fails when the credential kind is not supported by the selected profile.
+
+No provider adapter should perform refresh or hidden 401 recovery.
+
+### 5. Apply auth from selected credential and selected strategy
+
+Refactor shared auth header creation away from `api_key: &str` toward selected credential value plus auth strategy.
+
+Implementation shape can be either:
+
+- keep auth in client default headers at construction time using the selected credential, or
+- build a base client without auth and apply auth per request.
+
+Prefer request-time application for adapters where it is simple, especially Codex, because it keeps refreshed credential snapshots easier to reason about. It is acceptable for construction to validate credentials and for callers to rebuild providers after refresh.
+
+Important: keep timeout handling and fixed/default header validation centralized so behavior does not drift between adapters.
+
+### 6. Add `kimi-code` OAuth without changing `kimi`
+
+`kimi-code` should support:
+
+```text
+CredentialKind::ApiKey      -> AuthStrategy::ApiKeyHeader { header_name: "x-api-key" }
+CredentialKind::OAuthBearer -> AuthStrategy::BearerToken
+```
+
+General `kimi` remains API-key-only:
+
+```text
+CredentialKind::ApiKey -> AuthStrategy::BearerToken
+```
+
+Why this decision:
+
+- Kimi CLI showed Kimi Code OAuth access tokens are sent as bearer tokens.
+- Current `kimi-code` API-key behavior uses `x-api-key` and must continue working.
+- Adding a `kimi-code-oauth` slug would conflate provider identity with credential mode and complicate settings/model lookup.
+
+### 7. Add Codex as a new API family and provider profile
+
+Add:
+
+```rust
+ApiFamily::CodexResponses
+```
+
+Register built-in profile:
+
+```text
+slug: codex
+models_dev_id: openai
+family: CodexResponses
+base_url: https://chatgpt.com/backend-api/codex
+credential: OAuthBearer -> BearerToken
+purpose: Coding
+```
+
+Do not add OAuth behavior to standard `openai` as part of this change.
+
+Why this decision:
+
+- Codex uses ChatGPT/Codex backend endpoints, not public OpenAI endpoints.
+- `models_dev_id = "openai"` lets consumers reuse OpenAI/GPT capability metadata because models.dev has no Codex provider.
+- Separate family keeps exact Codex request requirements testable without bending existing OpenAI adapters.
+
+### 8. Implement Codex with raw HTTP and exact mocked assertions
+
+Add `src/codex.rs` with non-streaming and streaming functions matching the `Provider` dispatch pattern.
+
+Codex requests target:
+
+```text
+POST https://chatgpt.com/backend-api/codex/responses
+```
+
+Required request headers:
+
+```text
+Authorization: Bearer <access_token>
+originator: iron-providers
+User-Agent: iron-providers/<crate-version>
+chatgpt-account-id: <account_id>   # only when extracted
+Content-Type: application/json
+```
+
+Required body fields:
+
+```text
+model: <request model>
+input: <projected transcript/input>
+instructions: <request instructions when present>
+tools: <tool definitions when present>
+tool_choice: <tool policy projection when present>
+store: false
+reasoning: { effort: "medium" }
+parallel_tool_calls: true
+stream: true/false according to infer vs infer_stream
+```
+
+Reuse projection helpers from `openai` or extract shared Responses projection code only if it reduces duplication without coupling Codex to public OpenAI behavior. Do not introduce a large abstraction before tests prove duplication is harmful.
+
+### 9. Parse JWT payload claims for Codex routing metadata only
+
+Add a helper in a credential/auth module, for example:
+
+```rust
+pub(crate) fn chatgpt_account_id_from_jwt(id_token: &str) -> Option<String>
+```
+
+Parse JWT payloads unverified. This is only routing metadata extraction; provider servers still validate bearer tokens.
+
+Claim priority:
+
+1. top-level `chatgpt_account_id`
+2. nested `https://api.openai.com/auth.chatgpt_account_id`
+3. first `organizations[].id`
+
+Implementation note: if the crate does not already depend on a base64 decoder, add a small, focused dependency only if needed. Keep parsing tolerant: malformed tokens return `None` instead of failing provider construction.
+
+### 10. Keep model capability source external
+
+Codex profile should use `models_dev_id = "openai"`. The crate should not hard-code Goose's Codex model list or infer image capability internally. Consumers should derive model capabilities from models.dev metadata.
+
+## Risks / Trade-offs
+
+- Changing `RuntimeConfig` from `api_key` to `credential` is a public API change. Mitigation: keep `RuntimeConfig::new(api_key)` and update crate-local tests/examples; add compatibility only if real downstream usage requires it.
+- `async-openai` client construction currently expects API-key-like config for `OpenAiResponses`. Mitigation: standard `openai` remains API-key-only for this issue; Codex uses raw HTTP.
+- Request-time auth and client default auth may coexist temporarily. Mitigation: centralize auth header construction so semantics stay consistent.
+- Unverified JWT parsing can be misunderstood as auth validation. Mitigation: keep helper naming/docs explicit that it extracts non-authoritative routing metadata only.
+- Codex response/stream formats may drift. Mitigation: isolate in `src/codex.rs` and cover exact request behavior with mocked HTTP; response parsing can reuse existing event semantics where compatible.
+
+## Migration Plan
+
+1. Add credential types and preserve `RuntimeConfig::new(api_key)` behavior.
+2. Add profile credential metadata while keeping built-in API-key profiles equivalent.
+3. Update generic provider construction to select auth strategy by credential kind.
+4. Add Kimi Code OAuth support.
+5. Add Codex family/profile/adapter.
+6. Add tests for compatibility, errors, Kimi headers, Codex requests, and JWT parsing.
+
+Rollback is straightforward if done before release: remove Codex family/profile, remove credential-aware constructor, and revert profiles to single `auth_strategy`. After release, prefer additive fixes because the credential API becomes public.
+
+## Open Questions
+
+- Should `ProviderCredential` derive `Serialize`/`Deserialize`? The provider crate likely does not need to persist credentials, and avoiding serde may reduce accidental secret serialization. Add serde only if tests or known consumers need it.
+- Should `ProviderError` gain distinct enum variants or just helper constructors returning `Authentication`? Prefer helper constructors unless consumers require machine-readable subtypes.
+- Should auth headers move fully to request-time for all adapters now, or only where required? Prefer the smallest safe refactor that supports selected credential kinds and keeps tests clear.

--- a/openspec/changes/add-provider-credential-oauth/proposal.md
+++ b/openspec/changes/add-provider-credential-oauth/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+`iron-providers` currently treats every runtime secret as one long-lived API-key string. `RuntimeConfig` stores `api_key`, `ProviderProfile` stores a single `auth_strategy`, and `GenericProvider` builds clients with that one strategy at construction time. That is too narrow for OAuth-backed provider access.
+
+The first concrete providers that need this are `kimi-code` and a new ChatGPT/Codex-backed `codex` provider. `kimi-code` supports both API keys and OAuth bearer access tokens, but those credentials use different wire headers. Codex is not the public OpenAI API and should not change the existing `openai` provider; it uses ChatGPT/Codex endpoints with OAuth bearer auth.
+
+OAuth login, refresh-token storage, access-token refresh, and 401 retry orchestration belong in AgentIron, `iron-tui`, and `iron-core`. This crate should own only the provider-facing credential contract, supported credential metadata, request-time auth headers, validation, and provider-specific connection details.
+
+## What Changes
+
+- Add explicit credential types: `CredentialKind` and `ProviderCredential`.
+- Preserve `RuntimeConfig::new(api_key)` for existing API-key callers and add `RuntimeConfig::from_credential(credential)` for credential-aware callers.
+- Add profile metadata that maps supported credential kinds to wire `AuthStrategy` values.
+- Validate missing, unsupported, and expired credentials with clear authentication errors.
+- Update client/request construction so the selected credential kind determines the auth header.
+- Add OAuth bearer support to `kimi-code` while leaving `kimi` API-key-only.
+- Add a new `codex` provider profile using `models_dev_id = "openai"` and a new `ApiFamily::CodexResponses`.
+- Implement Codex request handling against `https://chatgpt.com/backend-api/codex/responses` using raw mocked HTTP coverage.
+- Parse optional Codex account routing metadata from unverified JWT payload claims when an OAuth credential includes an ID token.
+
+## Capabilities
+
+### New Capabilities
+
+- `provider-credential-oauth`: Defines provider runtime credential modeling, profile credential support metadata, OAuth bearer validation, Kimi Code OAuth header behavior, and Codex provider behavior.
+
+### Modified Capabilities
+
+- Existing provider registry/profile behavior gains credential-aware auth selection while preserving API-key compatibility.
+- Existing generic provider dispatch gains a Codex Responses family.
+
+## Impact
+
+- Affected code: `src/profile.rs`, `src/generic_provider.rs`, `src/http_client.rs`, `src/registry.rs`, `src/lib.rs`, `src/error.rs`, new credential/JWT helper module, new `src/codex.rs`, and tests.
+- Affected behavior: existing API-key providers continue to work; `kimi-code` can use API-key or OAuth bearer credentials; `codex` becomes available as an OAuth-backed provider.
+- API impact: additive credential API plus profile metadata changes. Preserve `RuntimeConfig::new(api_key)` and avoid breaking existing API-key construction.
+- Out of scope: OAuth login flows, refresh-token storage, refresh scheduling, app UI, `iron-core` retry orchestration, changing standard `openai`, adding OAuth to general `kimi`, and passing refresh tokens into this crate.
+
+## Related
+
+- AgentIron/iron-providers#13
+- AgentIron/iron-core#18
+- AgentIron/AgentIron#22
+- AgentIron/AgentIron#23

--- a/openspec/changes/add-provider-credential-oauth/specs/provider-credential-oauth/spec.md
+++ b/openspec/changes/add-provider-credential-oauth/specs/provider-credential-oauth/spec.md
@@ -1,0 +1,202 @@
+## ADDED Requirements
+
+### Requirement: Runtime credentials SHALL distinguish API keys from OAuth bearer tokens
+The provider runtime configuration SHALL represent API-key credentials and OAuth bearer credentials as distinct credential variants.
+
+#### Scenario: Existing API-key constructor remains usable
+- **WHEN** a caller constructs `RuntimeConfig::new("secret")`
+- **THEN** the runtime configuration contains an API-key credential with value `secret`
+- **AND** existing timeout builder methods remain available
+
+#### Scenario: Credential-aware constructor accepts API keys
+- **WHEN** a caller constructs `RuntimeConfig::from_credential(ProviderCredential::ApiKey("secret"))`
+- **THEN** the runtime configuration contains an API-key credential with value `secret`
+
+#### Scenario: Credential-aware constructor accepts OAuth bearer tokens
+- **WHEN** a caller constructs `RuntimeConfig::from_credential(ProviderCredential::OAuthBearer { access_token, expires_at, id_token })`
+- **THEN** the runtime configuration contains the OAuth bearer credential snapshot
+- **AND** no refresh token is represented in the runtime credential
+
+### Requirement: Provider profiles SHALL declare supported credential kinds
+Provider profiles SHALL expose which credential kinds they support and which wire auth strategy applies to each kind.
+
+#### Scenario: API-key-only provider supports API keys
+- **WHEN** a profile is configured with API-key auth only
+- **THEN** `CredentialKind::ApiKey` is supported
+- **AND** `CredentialKind::OAuthBearer` is not supported
+
+#### Scenario: Mixed-mode provider supports multiple credential kinds
+- **WHEN** a profile is configured with API-key and OAuth bearer auth configs
+- **THEN** both credential kinds are supported
+- **AND** each kind resolves to its configured `AuthStrategy`
+
+#### Scenario: Existing `with_auth` helper remains API-key oriented
+- **WHEN** built-in profiles call `with_auth(strategy)`
+- **THEN** the strategy applies to `CredentialKind::ApiKey`
+- **AND** existing API-key-only built-ins preserve their current wire auth behavior
+
+### Requirement: Provider construction SHALL validate credential compatibility
+Provider construction SHALL fail clearly when a runtime credential is missing, blank, unsupported by the profile, or expired.
+
+#### Scenario: Blank API key fails as authentication
+- **WHEN** a provider is constructed with a blank API-key credential
+- **THEN** construction fails with an authentication error describing the missing credential
+
+#### Scenario: Blank OAuth access token fails as authentication
+- **WHEN** a provider is constructed with an OAuth bearer credential whose access token is blank
+- **THEN** construction fails with an authentication error describing the missing credential
+
+#### Scenario: Unsupported credential kind fails before requests
+- **WHEN** a provider profile supports only API keys
+- **AND** the runtime credential is OAuth bearer
+- **THEN** provider construction fails with an authentication error describing the unsupported credential kind
+
+#### Scenario: Expired OAuth bearer token fails before requests
+- **WHEN** an OAuth bearer credential has `expires_at` at or before the current system time
+- **THEN** provider construction or pre-request validation fails with an authentication error describing the expired credential
+
+#### Scenario: OAuth bearer token without expiry is accepted
+- **WHEN** an OAuth bearer credential has `expires_at: None`
+- **THEN** expiry validation does not reject the credential
+
+### Requirement: Auth headers SHALL be built from the selected credential and strategy
+Provider requests SHALL apply the auth strategy associated with the runtime credential kind, using the selected credential value.
+
+#### Scenario: Bearer strategy uses Authorization header
+- **WHEN** a selected credential value is applied with `AuthStrategy::BearerToken`
+- **THEN** requests include `Authorization: Bearer <credential>`
+
+#### Scenario: API-key header strategy uses configured header name
+- **WHEN** a selected credential value is applied with `AuthStrategy::ApiKeyHeader { header_name }`
+- **THEN** requests include `<header_name>: <credential>`
+
+#### Scenario: Custom strategy preserves prefix behavior
+- **WHEN** a selected credential value is applied with `AuthStrategy::Custom { header_name, prefix }`
+- **THEN** requests include the configured header with either `<prefix> <credential>` or the raw credential when no prefix exists
+
+### Requirement: Kimi Code SHALL support API-key and OAuth bearer credentials
+The built-in `kimi-code` profile SHALL support both API-key and OAuth bearer credentials with distinct wire headers.
+
+#### Scenario: Kimi Code API key uses x-api-key
+- **WHEN** a caller constructs `kimi-code` with an API-key credential
+- **THEN** provider requests use `x-api-key: <api_key>`
+
+#### Scenario: Kimi Code OAuth uses bearer auth
+- **WHEN** a caller constructs `kimi-code` with an OAuth bearer credential
+- **THEN** provider requests use `Authorization: Bearer <access_token>`
+
+#### Scenario: Kimi general remains API-key-only
+- **WHEN** a caller constructs `kimi` with an OAuth bearer credential
+- **THEN** construction fails with an unsupported credential authentication error
+
+### Requirement: Codex provider SHALL be registered as a distinct provider
+The provider registry SHALL include a built-in `codex` profile for ChatGPT/Codex-backed access without changing the standard `openai` provider path.
+
+#### Scenario: Codex built-in profile exists
+- **WHEN** the default provider registry is constructed
+- **THEN** its slugs include `codex`
+- **AND** the `codex` profile has `models_dev_id` set to `openai`
+- **AND** the profile uses `ApiFamily::CodexResponses`
+
+#### Scenario: Codex requires OAuth bearer credentials
+- **WHEN** a caller constructs `codex` with an OAuth bearer credential
+- **THEN** construction succeeds when the token is non-empty and not expired
+
+#### Scenario: Codex rejects API-key credentials unless explicitly supported later
+- **WHEN** a caller constructs `codex` with an API-key credential
+- **THEN** construction fails with an unsupported credential authentication error
+
+### Requirement: Codex requests SHALL target the ChatGPT/Codex Responses endpoint
+Codex inference SHALL send Responses-like HTTP requests to the ChatGPT/Codex backend endpoint.
+
+#### Scenario: Non-streaming Codex request uses the Codex responses URL
+- **WHEN** `GenericProvider` dispatches a non-streaming request for `ApiFamily::CodexResponses`
+- **THEN** it sends `POST https://chatgpt.com/backend-api/codex/responses`
+- **AND** the body includes `stream: false`
+
+#### Scenario: Streaming Codex request uses the Codex responses URL
+- **WHEN** `GenericProvider` dispatches a streaming request for `ApiFamily::CodexResponses`
+- **THEN** it sends `POST https://chatgpt.com/backend-api/codex/responses`
+- **AND** the body includes `stream: true`
+
+#### Scenario: Codex request includes required fixed body fields
+- **WHEN** a Codex request body is built
+- **THEN** it includes `store: false`
+- **AND** it includes `reasoning.effort: "medium"`
+- **AND** it includes `parallel_tool_calls: true`
+
+#### Scenario: Codex request includes normalized request fields
+- **WHEN** a Codex request body is built from an `InferenceRequest`
+- **THEN** it includes the request model
+- **AND** it includes instructions when present
+- **AND** it includes projected transcript/input content
+- **AND** it includes tools and tool choice when present
+
+### Requirement: Codex requests SHALL include required headers
+Codex requests SHALL include provider-required auth and product identification headers.
+
+#### Scenario: Codex request includes bearer auth
+- **WHEN** a Codex request is sent with OAuth bearer credential `token`
+- **THEN** it includes `Authorization: Bearer token`
+
+#### Scenario: Codex request includes product headers
+- **WHEN** a Codex request is sent
+- **THEN** it includes `originator: iron-providers`
+- **AND** it includes `User-Agent: iron-providers/<crate-version>`
+
+#### Scenario: Codex request includes account routing header when available
+- **WHEN** a Codex OAuth credential includes an ID token with extractable account metadata
+- **THEN** the request includes `chatgpt-account-id: <account_id>`
+
+#### Scenario: Codex request omits account routing header when unavailable
+- **WHEN** a Codex OAuth credential has no ID token or no extractable account metadata
+- **THEN** the request omits `chatgpt-account-id`
+- **AND** the request can still be sent
+
+### Requirement: JWT account routing metadata SHALL be parsed without verification
+The crate SHALL extract optional ChatGPT account routing metadata from JWT payload claims for request-header routing only.
+
+#### Scenario: Top-level account claim wins
+- **WHEN** an ID token payload contains top-level `chatgpt_account_id`
+- **THEN** that value is used as the ChatGPT account ID
+
+#### Scenario: Nested account claim is used second
+- **WHEN** an ID token payload lacks top-level `chatgpt_account_id`
+- **AND** contains `https://api.openai.com/auth.chatgpt_account_id`
+- **THEN** that nested value is used as the ChatGPT account ID
+
+#### Scenario: Organization ID is fallback
+- **WHEN** an ID token payload lacks both ChatGPT account claims
+- **AND** contains `organizations[0].id`
+- **THEN** that organization ID is used as the ChatGPT account ID
+
+#### Scenario: Malformed JWT produces no account ID
+- **WHEN** an ID token is malformed or has invalid JSON payload
+- **THEN** account ID extraction returns `None`
+- **AND** provider construction does not fail solely because account metadata is unavailable
+
+### Requirement: Provider behavior SHALL not own OAuth refresh lifecycle
+The provider crate SHALL not receive refresh tokens and SHALL not perform OAuth refresh or hidden retry orchestration.
+
+#### Scenario: Runtime credential contains no refresh token
+- **WHEN** callers build any supported `ProviderCredential`
+- **THEN** there is no field for refresh-token material
+
+#### Scenario: Unauthorized response is surfaced
+- **WHEN** a provider receives an unrecoverable unauthorized response from the backend
+- **THEN** the provider returns an authentication error
+- **AND** it does not attempt token refresh internally
+
+## MODIFIED Requirements
+
+### Requirement: GenericProvider SHALL dispatch all supported API families
+`GenericProvider` SHALL dispatch inference and streaming requests for every registered `ApiFamily` variant.
+
+#### Scenario: Codex Responses dispatches to Codex adapter
+- **WHEN** a profile has `family` set to `ApiFamily::CodexResponses`
+- **THEN** `GenericProvider::infer` dispatches to the Codex non-streaming adapter
+- **AND** `GenericProvider::infer_stream` dispatches to the Codex streaming adapter
+
+#### Scenario: Existing families continue dispatching as before
+- **WHEN** a profile has an existing family such as `OpenAiResponses`, `OpenAiChatCompletions`, or `AnthropicMessages`
+- **THEN** dispatch behavior remains compatible with the existing adapter path

--- a/openspec/changes/add-provider-credential-oauth/tasks.md
+++ b/openspec/changes/add-provider-credential-oauth/tasks.md
@@ -1,0 +1,100 @@
+## 1. Credential Model
+
+- [x] 1.1 Add `CredentialKind` with `ApiKey` and `OAuthBearer` variants.
+- [x] 1.2 Add `ProviderCredential` with `ApiKey(String)` and `OAuthBearer { access_token, expires_at, id_token }` variants.
+- [x] 1.3 Update `RuntimeConfig` to store `ProviderCredential` while preserving connect/read timeout fields.
+- [x] 1.4 Preserve `RuntimeConfig::new(api_key)` as API-key shorthand.
+- [x] 1.5 Add `RuntimeConfig::from_credential(credential)`.
+- [x] 1.6 Update `RuntimeConfigSource` call sites/tests for the credential-backed runtime shape.
+
+## 2. Profile Auth Metadata
+
+- [x] 2.1 Add `CredentialAuthConfig { kind, auth_strategy }`.
+- [x] 2.2 Replace or supersede `ProviderProfile.auth_strategy` with `credential_auth: Vec<CredentialAuthConfig>`.
+- [x] 2.3 Keep `ProviderProfile::new(...)` default behavior equivalent to API-key bearer auth.
+- [x] 2.4 Keep `ProviderProfile::with_auth(strategy)` as an API-key auth helper for existing built-ins.
+- [x] 2.5 Add `ProviderProfile::with_credential_auth(kind, strategy)`.
+- [x] 2.6 Add helper methods for supported credential lookup, such as `supports_credential` and `auth_strategy_for`.
+- [x] 2.7 Update all built-in registry profiles to preserve existing API-key auth behavior.
+
+## 3. Auth Validation And Header Application
+
+- [x] 3.1 Add clear authentication error helpers/messages for missing, unsupported, and expired credentials.
+- [x] 3.2 Validate blank API keys and blank OAuth access tokens as authentication failures.
+- [x] 3.3 Validate unsupported credential kind during provider construction.
+- [x] 3.4 Validate expired OAuth bearer credentials before requests or during construction.
+- [x] 3.5 Allow OAuth bearer credentials with `expires_at: None`.
+- [x] 3.6 Refactor shared auth header construction to use selected credential value plus selected `AuthStrategy` rather than `api_key` plus single profile strategy.
+- [x] 3.7 Preserve timeout, default header, and fixed header validation behavior.
+
+## 4. Kimi Code OAuth Support
+
+- [x] 4.1 Update `kimi-code` built-in profile to support API-key auth with `x-api-key`.
+- [x] 4.2 Add OAuth bearer auth support to `kimi-code` with `Authorization: Bearer <access_token>`.
+- [x] 4.3 Ensure general `kimi` remains API-key-only.
+- [x] 4.4 Add tests for `kimi-code` API-key header behavior.
+- [x] 4.5 Add tests for `kimi-code` OAuth bearer header behavior.
+- [x] 4.6 Add tests that `kimi` rejects OAuth bearer credentials.
+
+## 5. Codex Provider Profile And Dispatch
+
+- [x] 5.1 Add `ApiFamily::CodexResponses`.
+- [x] 5.2 Add `src/codex.rs` module and export it from `src/lib.rs` as appropriate.
+- [x] 5.3 Register built-in `codex` profile with base URL `https://chatgpt.com/backend-api/codex`.
+- [x] 5.4 Set `codex` profile `models_dev_id` to `openai`.
+- [x] 5.5 Set `codex` profile purpose to coding.
+- [x] 5.6 Configure `codex` to support OAuth bearer credentials.
+- [x] 5.7 Ensure `codex` rejects API-key credentials unless explicit API-key support is added later.
+- [x] 5.8 Update `GenericProvider` non-streaming dispatch for `CodexResponses`.
+- [x] 5.9 Update `GenericProvider` streaming dispatch for `CodexResponses`.
+
+## 6. Codex Request Implementation
+
+- [x] 6.1 Build Codex non-streaming requests to `POST {base_url}/responses` with `stream: false`.
+- [x] 6.2 Build Codex streaming requests to `POST {base_url}/responses` with `stream: true`.
+- [x] 6.3 Include `store: false` in every Codex request body.
+- [x] 6.4 Include `reasoning: { effort: "medium" }` in every Codex request body.
+- [x] 6.5 Include `parallel_tool_calls: true` in every Codex request body.
+- [x] 6.6 Project model, instructions, transcript/input, tools, and tool choice from `InferenceRequest`.
+- [x] 6.7 Include `originator: iron-providers` on Codex requests.
+- [x] 6.8 Include `User-Agent: iron-providers/<crate-version>` on Codex requests.
+- [x] 6.9 Include `chatgpt-account-id` only when account metadata is extracted.
+- [x] 6.10 Map Codex unauthorized responses to authentication errors without refresh attempts.
+- [x] 6.11 Implement response parsing into existing `ProviderEvent` semantics for non-streaming and streaming paths.
+
+## 7. JWT Account Metadata
+
+- [x] 7.1 Add a focused helper for unverified JWT payload parsing.
+- [x] 7.2 Extract top-level `chatgpt_account_id` with highest priority.
+- [x] 7.3 Extract nested `https://api.openai.com/auth.chatgpt_account_id` with second priority.
+- [x] 7.4 Extract first `organizations[].id` as fallback.
+- [x] 7.5 Return `None` for malformed JWTs, invalid payload JSON, or missing account metadata.
+- [x] 7.6 Document that JWT parsing is routing metadata extraction, not auth verification.
+
+## 8. Tests
+
+- [x] 8.1 Add tests for `RuntimeConfig::new` preserving API-key behavior.
+- [x] 8.2 Add tests for `RuntimeConfig::from_credential` with API-key and OAuth bearer credentials.
+- [x] 8.3 Add tests for profile credential support lookup and per-kind auth strategy selection.
+- [x] 8.4 Add tests for missing, unsupported, and expired credential errors.
+- [x] 8.5 Add mocked HTTP tests for existing API-key providers to catch auth header regressions where practical.
+- [x] 8.6 Add mocked raw HTTP tests for `kimi-code` API-key and OAuth headers.
+- [x] 8.7 Add mocked raw HTTP tests for Codex URL, headers, and required body fields.
+- [x] 8.8 Add tests for Codex account ID header inclusion and omission.
+- [x] 8.9 Add JWT parsing tests using fake JWT payloads for each claim priority and malformed input.
+- [x] 8.10 Add registry tests confirming `codex` is registered and maps to `models_dev_id = "openai"`.
+- [x] 8.11 Add dispatch tests or mocked integration tests confirming `ApiFamily::CodexResponses` routes through the Codex adapter.
+
+## 9. Documentation And Examples
+
+- [x] 9.1 Update README or crate docs to show API-key construction still works.
+- [x] 9.2 Add a credential-aware construction example with `ProviderCredential::OAuthBearer`.
+- [x] 9.3 Document that refresh tokens and OAuth refresh flows are owned by consuming layers, not `iron-providers`.
+- [x] 9.4 Document `kimi-code` dual auth modes and `codex` OAuth-only behavior.
+
+## 10. Verification
+
+- [x] 10.1 Run `cargo build --locked --all-targets`.
+- [x] 10.2 Run `cargo fmt --manifest-path Cargo.toml -- --check`.
+- [x] 10.3 Run `cargo clippy --locked --all-targets --all-features -- -D warnings`.
+- [x] 10.4 Run `cargo test --locked`.

--- a/src/anthropic.rs
+++ b/src/anthropic.rs
@@ -91,10 +91,17 @@ fn build_client(
     runtime: &crate::profile::RuntimeConfig,
 ) -> ProviderResult<Client> {
     let context = format!("profile '{}'", profile.slug);
+    let kind = runtime.credential.kind();
+    let auth_strategy = profile.auth_strategy_for(kind).ok_or_else(|| {
+        ProviderError::auth(format!(
+            "Provider '{}' does not support {:?} credentials",
+            profile.slug, kind
+        ))
+    })?;
     crate::http_client::build_http_client(crate::http_client::HttpClientParams {
         context: &context,
-        api_key: &runtime.api_key,
-        auth_strategy: &profile.auth_strategy,
+        credential: &runtime.credential,
+        auth_strategy,
         default_headers: &profile.default_headers,
         extra_headers: &[("anthropic-version", "2023-06-01")],
         connect_timeout: runtime.effective_connect_timeout(),

--- a/src/codex.rs
+++ b/src/codex.rs
@@ -1,0 +1,464 @@
+//! Codex provider adapter for ChatGPT/Codex backend access.
+//!
+//! Uses raw HTTP against `https://chatgpt.com/backend-api/codex/responses`.
+//! Does not depend on `async-openai` so exact request/response behavior can be
+//! asserted in mocked tests.
+
+use crate::{
+    model::{ProviderEvent, ToolCall},
+    profile::{ProviderCredential, ProviderProfile, RuntimeConfig},
+    InferenceRequest, ProviderError, ProviderResult,
+};
+use futures::stream::{BoxStream, StreamExt};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+/// Parse an unverified JWT payload and extract the ChatGPT account ID if present.
+///
+/// This is routing metadata extraction only; the provider server still validates
+/// the bearer token authoritatively.
+pub(crate) fn chatgpt_account_id_from_jwt(id_token: &str) -> Option<String> {
+    let payload_b64 = id_token.split('.').nth(1)?;
+    let payload_json = base64_decode_url_safe(payload_b64).ok()?;
+    let payload: Value = serde_json::from_slice(&payload_json).ok()?;
+
+    payload
+        .get("chatgpt_account_id")
+        .and_then(|v| v.as_str().map(String::from))
+        .or_else(|| {
+            payload
+                .get("https://api.openai.com/auth")
+                .and_then(|nested| nested.get("chatgpt_account_id"))
+                .and_then(|v| v.as_str().map(String::from))
+        })
+        .or_else(|| {
+            payload
+                .get("organizations")
+                .and_then(|orgs| orgs.as_array())
+                .and_then(|orgs| orgs.first())
+                .and_then(|first| first.get("id"))
+                .and_then(|v| v.as_str().map(String::from))
+        })
+}
+
+fn base64_decode_url_safe(input: &str) -> Result<Vec<u8>, base64::DecodeError> {
+    use base64::{engine::general_purpose, Engine as _};
+    let padded = match input.len() % 4 {
+        0 => input.to_string(),
+        n => format!("{}{}", input, "=".repeat(4 - n)),
+    };
+    general_purpose::URL_SAFE_NO_PAD.decode(padded.trim_end_matches('='))
+}
+
+fn build_codex_headers(
+    runtime: &RuntimeConfig,
+    crate_version: &str,
+) -> ProviderResult<Vec<(String, String)>> {
+    let mut headers = vec![
+        ("originator".to_string(), "iron-providers".to_string()),
+        (
+            "User-Agent".to_string(),
+            format!("iron-providers/{}", crate_version),
+        ),
+    ];
+
+    if let ProviderCredential::OAuthBearer {
+        id_token: Some(ref token),
+        ..
+    } = runtime.credential
+    {
+        if let Some(account_id) = chatgpt_account_id_from_jwt(token) {
+            headers.push(("chatgpt-account-id".to_string(), account_id));
+        }
+    }
+
+    Ok(headers)
+}
+
+fn build_codex_request_body(request: &InferenceRequest, stream: bool) -> ProviderResult<Value> {
+    let mut body = json!({
+        "model": request.model,
+        "store": false,
+        "reasoning": { "effort": "medium" },
+        "parallel_tool_calls": true,
+        "stream": stream,
+    });
+
+    if let Some(ref instructions) = request.instructions {
+        body["instructions"] = json!(instructions);
+    }
+
+    let input_items: Vec<Value> = request
+        .context
+        .transcript
+        .messages
+        .iter()
+        .map(|msg| match msg {
+            crate::Message::User { content } => {
+                json!({ "role": "user", "content": [{"type": "text", "text": content}] })
+            }
+            crate::Message::Assistant { content } => {
+                json!({ "role": "assistant", "content": content })
+            }
+            crate::Message::AssistantToolCall {
+                call_id,
+                tool_name,
+                arguments,
+            } => json!({
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{
+                    "id": call_id,
+                    "type": "function",
+                    "function": {
+                        "name": tool_name,
+                        "arguments": arguments,
+                    }
+                }],
+            }),
+            crate::Message::Tool {
+                call_id,
+                tool_name: _,
+                result,
+            } => json!({
+                "type": "function_call_output",
+                "call_id": call_id,
+                "output": result.to_string(),
+            }),
+        })
+        .collect();
+    body["input"] = json!(input_items);
+
+    if !request.tools.is_empty() {
+        let tool_defs: Vec<Value> = request
+            .tools
+            .iter()
+            .map(|t| {
+                json!({
+                    "type": "function",
+                    "name": t.name,
+                    "description": t.description,
+                    "parameters": t.input_schema,
+                })
+            })
+            .collect();
+        body["tools"] = json!(tool_defs);
+
+        body["tool_choice"] = match request.tool_policy {
+            crate::model::ToolPolicy::Auto => json!("auto"),
+            crate::model::ToolPolicy::Required => json!("required"),
+            crate::model::ToolPolicy::None => json!("none"),
+            crate::model::ToolPolicy::Specific(ref name) => json!({
+                "type": "function",
+                "function": { "name": name }
+            }),
+        };
+    }
+
+    Ok(body)
+}
+
+fn build_reqwest_headers(extra: &[(String, String)]) -> ProviderResult<reqwest::header::HeaderMap> {
+    let mut h = reqwest::header::HeaderMap::new();
+    for (k, v) in extra {
+        let name = reqwest::header::HeaderName::from_bytes(k.as_bytes()).map_err(|e| {
+            ProviderError::invalid_request(format!("Invalid Codex header name '{}': {}", k, e))
+        })?;
+        let value = reqwest::header::HeaderValue::from_str(v).map_err(|e| {
+            ProviderError::invalid_request(format!("Invalid Codex header value for '{}': {}", k, e))
+        })?;
+        h.insert(name, value);
+    }
+    Ok(h)
+}
+
+/// Non-streaming Codex inference.
+pub async fn infer(
+    client: reqwest::Client,
+    profile: &ProviderProfile,
+    runtime: &RuntimeConfig,
+    request: InferenceRequest,
+) -> ProviderResult<Vec<ProviderEvent>> {
+    let url = format!("{}/responses", profile.base_url);
+    let extra_headers = build_codex_headers(runtime, env!("CARGO_PKG_VERSION"))?;
+    let body = build_codex_request_body(&request, false)?;
+    let headers = build_reqwest_headers(&extra_headers)?;
+
+    let response = client
+        .post(&url)
+        .json(&body)
+        .headers(headers)
+        .send()
+        .await
+        .map_err(|e| ProviderError::transport(format!("Codex request failed: {}", e)))?;
+
+    let status = response.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        return Err(ProviderError::auth("Codex returned 401 Unauthorized"));
+    }
+    if !status.is_success() {
+        let text = response
+            .text()
+            .await
+            .unwrap_or_else(|_| format!("HTTP {}", status));
+        return Err(ProviderError::general(format!(
+            "Codex request failed with {}: {}",
+            status, text
+        )));
+    }
+
+    let data: CodexResponse = response
+        .json()
+        .await
+        .map_err(|e| ProviderError::malformed(format!("Failed to parse Codex response: {}", e)))?;
+
+    parse_codex_response(data)
+}
+
+/// Streaming Codex inference.
+pub async fn infer_stream(
+    client: reqwest::Client,
+    profile: &ProviderProfile,
+    runtime: &RuntimeConfig,
+    request: InferenceRequest,
+) -> ProviderResult<BoxStream<'static, ProviderResult<ProviderEvent>>> {
+    let url = format!("{}/responses", profile.base_url);
+    let extra_headers = build_codex_headers(runtime, env!("CARGO_PKG_VERSION"))?;
+    let body = build_codex_request_body(&request, true)?;
+    let headers = build_reqwest_headers(&extra_headers)?;
+
+    let response = client
+        .post(&url)
+        .json(&body)
+        .headers(headers)
+        .send()
+        .await
+        .map_err(|e| ProviderError::transport(format!("Codex request failed: {}", e)))?;
+
+    let status = response.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        return Err(ProviderError::auth("Codex returned 401 Unauthorized"));
+    }
+    if !status.is_success() {
+        let text = response
+            .text()
+            .await
+            .unwrap_or_else(|_| format!("HTTP {}", status));
+        return Err(ProviderError::general(format!(
+            "Codex request failed with {}: {}",
+            status, text
+        )));
+    }
+
+    let stream = response.bytes_stream();
+    let mut parser = crate::sse::SseParser::new();
+
+    let events = stream.map(move |chunk| match chunk {
+        Ok(bytes) => {
+            let sse_events = parser.feed(&bytes);
+            let provider_events: Vec<ProviderResult<ProviderEvent>> = sse_events
+                .into_iter()
+                .filter_map(|evt| {
+                    if evt.data.trim() == "[DONE]" {
+                        return Some(Ok(ProviderEvent::Complete));
+                    }
+                    let parsed: CodexStreamEvent = serde_json::from_str(&evt.data).ok()?;
+                    parsed
+                        .delta
+                        .map(|delta| Ok(ProviderEvent::Output { content: delta }))
+                })
+                .collect();
+            futures::stream::iter(provider_events)
+        }
+        Err(e) => futures::stream::iter(vec![Err(ProviderError::transport(format!(
+            "Codex stream error: {}",
+            e
+        )))]),
+    });
+
+    let flattened = events.flatten();
+    Ok(Box::pin(flattened))
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexResponse {
+    output: Option<Vec<CodexOutputItem>>,
+    #[serde(default)]
+    error: Option<CodexErrorBody>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexOutputItem {
+    #[serde(rename = "type")]
+    kind: String,
+    content: Option<Vec<CodexContentBlock>>,
+    arguments: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexContentBlock {
+    #[serde(rename = "type")]
+    kind: String,
+    text: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexErrorBody {
+    message: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexStreamEvent {
+    delta: Option<String>,
+}
+
+fn parse_codex_response(data: CodexResponse) -> ProviderResult<Vec<ProviderEvent>> {
+    if let Some(err) = data.error {
+        return Err(ProviderError::general(format!(
+            "Codex error: {}",
+            err.message
+        )));
+    }
+
+    let mut events = Vec::new();
+    if let Some(output) = data.output {
+        for item in output {
+            match item.kind.as_str() {
+                "message" => {
+                    if let Some(content) = item.content {
+                        for block in content {
+                            if block.kind == "output_text" {
+                                if let Some(text) = block.text {
+                                    events.push(ProviderEvent::Output { content: text });
+                                }
+                            }
+                        }
+                    }
+                }
+                "function_call" => {
+                    if let Some(args) = item.arguments {
+                        events.push(ProviderEvent::ToolCall {
+                            call: ToolCall {
+                                call_id: "codex-call".to_string(),
+                                tool_name: "function".to_string(),
+                                arguments: serde_json::Value::String(args),
+                            },
+                        });
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    events.push(ProviderEvent::Complete);
+    Ok(events)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fake_jwt(payload: &str) -> String {
+        use base64::{engine::general_purpose, Engine as _};
+        let header = general_purpose::URL_SAFE_NO_PAD.encode(b"{}");
+        let payload_b64 = general_purpose::URL_SAFE_NO_PAD.encode(payload.as_bytes());
+        let sig = general_purpose::URL_SAFE_NO_PAD.encode(b"signature");
+        format!("{}.{}.{}", header, payload_b64, sig)
+    }
+
+    #[test]
+    fn test_jwt_top_level_account_id() {
+        let payload = r#"{"chatgpt_account_id":"acct_123"}"#;
+        let jwt = fake_jwt(payload);
+        assert_eq!(
+            chatgpt_account_id_from_jwt(&jwt),
+            Some("acct_123".to_string())
+        );
+    }
+
+    #[test]
+    fn test_jwt_nested_account_id() {
+        let payload = r#"{"https://api.openai.com/auth":{"chatgpt_account_id":"acct_456"}}"#;
+        let jwt = fake_jwt(payload);
+        assert_eq!(
+            chatgpt_account_id_from_jwt(&jwt),
+            Some("acct_456".to_string())
+        );
+    }
+
+    #[test]
+    fn test_jwt_organization_fallback() {
+        let payload = r#"{"organizations":[{"id":"org_789"}]}"#;
+        let jwt = fake_jwt(payload);
+        assert_eq!(
+            chatgpt_account_id_from_jwt(&jwt),
+            Some("org_789".to_string())
+        );
+    }
+
+    #[test]
+    fn test_jwt_top_level_wins_over_nested() {
+        let payload = r#"{"chatgpt_account_id":"top","https://api.openai.com/auth":{"chatgpt_account_id":"nested"}}"#;
+        let jwt = fake_jwt(payload);
+        assert_eq!(chatgpt_account_id_from_jwt(&jwt), Some("top".to_string()));
+    }
+
+    #[test]
+    fn test_jwt_malformed_returns_none() {
+        assert_eq!(chatgpt_account_id_from_jwt("not-a-jwt"), None);
+        assert_eq!(chatgpt_account_id_from_jwt("only-one-part"), None);
+    }
+
+    #[test]
+    fn test_jwt_no_claims_returns_none() {
+        let jwt = fake_jwt(r#"{"sub":"user"}"#);
+        assert_eq!(chatgpt_account_id_from_jwt(&jwt), None);
+    }
+
+    #[test]
+    fn test_build_codex_request_body_fields() {
+        let request = InferenceRequest::new("gpt-5.3-codex", crate::Transcript::new());
+        let body = build_codex_request_body(&request, false).unwrap();
+        assert_eq!(body["model"], "gpt-5.3-codex");
+        assert_eq!(body["store"], false);
+        assert_eq!(body["reasoning"]["effort"], "medium");
+        assert_eq!(body["parallel_tool_calls"], true);
+        assert_eq!(body["stream"], false);
+    }
+
+    #[test]
+    fn test_build_codex_request_body_stream() {
+        let request = InferenceRequest::new("gpt-5.3-codex", crate::Transcript::new());
+        let body = build_codex_request_body(&request, true).unwrap();
+        assert_eq!(body["stream"], true);
+    }
+
+    #[test]
+    fn test_build_codex_headers_without_id_token() {
+        let runtime = RuntimeConfig::from_credential(ProviderCredential::OAuthBearer {
+            access_token: "tok".into(),
+            expires_at: None,
+            id_token: None,
+        });
+        let headers = build_codex_headers(&runtime, "0.1.8").unwrap();
+        assert!(headers.iter().any(|(k, _)| k == "originator"));
+        assert!(headers.iter().any(|(k, _)| k == "User-Agent"));
+        assert!(!headers.iter().any(|(k, _)| k == "chatgpt-account-id"));
+    }
+
+    #[test]
+    fn test_build_codex_headers_with_account_id() {
+        let payload = r#"{"chatgpt_account_id":"acct_abc"}"#;
+        let jwt = fake_jwt(payload);
+        let runtime = RuntimeConfig::from_credential(ProviderCredential::OAuthBearer {
+            access_token: "tok".into(),
+            expires_at: None,
+            id_token: Some(jwt),
+        });
+        let headers = build_codex_headers(&runtime, "0.1.8").unwrap();
+        assert!(headers
+            .iter()
+            .any(|(k, v)| k == "chatgpt-account-id" && v == "acct_abc"));
+    }
+}

--- a/src/codex.rs
+++ b/src/codex.rs
@@ -289,6 +289,9 @@ struct CodexResponse {
 
 #[derive(Debug, Deserialize)]
 struct CodexOutputItem {
+    id: Option<String>,
+    call_id: Option<String>,
+    name: Option<String>,
     #[serde(rename = "type")]
     kind: String,
     content: Option<Vec<CodexContentBlock>>,
@@ -337,11 +340,16 @@ fn parse_codex_response(data: CodexResponse) -> ProviderResult<Vec<ProviderEvent
                 }
                 "function_call" => {
                     if let Some(args) = item.arguments {
+                        let arguments =
+                            serde_json::from_str(&args).unwrap_or(serde_json::Value::String(args));
                         events.push(ProviderEvent::ToolCall {
                             call: ToolCall {
-                                call_id: "codex-call".to_string(),
-                                tool_name: "function".to_string(),
-                                arguments: serde_json::Value::String(args),
+                                call_id: item
+                                    .call_id
+                                    .or(item.id)
+                                    .unwrap_or_else(|| "codex-call".to_string()),
+                                tool_name: item.name.unwrap_or_else(|| "function".to_string()),
+                                arguments,
                             },
                         });
                     }
@@ -358,6 +366,11 @@ fn parse_codex_response(data: CodexResponse) -> ProviderResult<Vec<ProviderEvent
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        generic_provider::GenericProvider, profile::CredentialKind, provider::Provider,
+        AuthStrategy, Message, Transcript,
+    };
+    use mockito::Matcher;
 
     fn fake_jwt(payload: &str) -> String {
         use base64::{engine::general_purpose, Engine as _};
@@ -365,6 +378,12 @@ mod tests {
         let payload_b64 = general_purpose::URL_SAFE_NO_PAD.encode(payload.as_bytes());
         let sig = general_purpose::URL_SAFE_NO_PAD.encode(b"signature");
         format!("{}.{}.{}", header, payload_b64, sig)
+    }
+
+    fn codex_profile(base_url: &str) -> ProviderProfile {
+        ProviderProfile::new("codex", crate::ApiFamily::CodexResponses, base_url)
+            .with_models_dev_id("openai")
+            .with_credential_auth(CredentialKind::OAuthBearer, AuthStrategy::BearerToken)
     }
 
     #[test]
@@ -460,5 +479,129 @@ mod tests {
         assert!(headers
             .iter()
             .any(|(k, v)| k == "chatgpt-account-id" && v == "acct_abc"));
+    }
+
+    #[test]
+    fn test_parse_codex_response_preserves_tool_call_metadata() {
+        let response = CodexResponse {
+            output: Some(vec![CodexOutputItem {
+                id: Some("fc_123".into()),
+                call_id: Some("call_123".into()),
+                name: Some("lookup".into()),
+                kind: "function_call".into(),
+                content: None,
+                arguments: Some(r#"{"query":"rust"}"#.into()),
+            }]),
+            error: None,
+        };
+
+        let events = parse_codex_response(response).unwrap();
+        let tool_call = events
+            .iter()
+            .find_map(|event| match event {
+                ProviderEvent::ToolCall { call } => Some(call),
+                _ => None,
+            })
+            .expect("tool call");
+
+        assert_eq!(tool_call.call_id, "call_123");
+        assert_eq!(tool_call.tool_name, "lookup");
+        assert_eq!(tool_call.arguments["query"], "rust");
+    }
+
+    #[tokio::test]
+    async fn test_codex_infer_sends_required_url_headers_and_body() {
+        let mut server = mockito::Server::new_async().await;
+        let id_token = fake_jwt(r#"{"chatgpt_account_id":"acct_abc"}"#);
+
+        let mock = server
+            .mock("POST", "/responses")
+            .match_header("authorization", "Bearer codex-token")
+            .match_header("originator", "iron-providers")
+            .match_header(
+                "user-agent",
+                format!("iron-providers/{}", env!("CARGO_PKG_VERSION")).as_str(),
+            )
+            .match_header("chatgpt-account-id", "acct_abc")
+            .match_body(Matcher::PartialJson(json!({
+                "model": "gpt-5.5",
+                "store": false,
+                "reasoning": { "effort": "medium" },
+                "parallel_tool_calls": true,
+                "stream": false,
+                "instructions": "Be terse"
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}"#,
+            )
+            .create_async()
+            .await;
+
+        let runtime = RuntimeConfig::from_credential(ProviderCredential::OAuthBearer {
+            access_token: "codex-token".into(),
+            expires_at: None,
+            id_token: Some(id_token),
+        });
+        let provider =
+            GenericProvider::from_profile(codex_profile(&server.url()), runtime).unwrap();
+        let request = InferenceRequest::new(
+            "gpt-5.5",
+            Transcript::with_messages(vec![Message::user("hello")]),
+        )
+        .with_instructions("Be terse");
+
+        let events = provider.infer(request).await.unwrap();
+        mock.assert_async().await;
+
+        assert!(events
+            .iter()
+            .any(|event| matches!(event, ProviderEvent::Output { content } if content == "ok")));
+    }
+
+    #[tokio::test]
+    async fn test_codex_stream_sends_stream_true_and_parses_sse() {
+        let mut server = mockito::Server::new_async().await;
+
+        let mock = server
+            .mock("POST", "/responses")
+            .match_header("authorization", "Bearer codex-token")
+            .match_header("chatgpt-account-id", Matcher::Missing)
+            .match_body(Matcher::PartialJson(json!({
+                "model": "gpt-5.5",
+                "store": false,
+                "reasoning": { "effort": "medium" },
+                "parallel_tool_calls": true,
+                "stream": true
+            })))
+            .with_status(200)
+            .with_header("content-type", "text/event-stream")
+            .with_body("data: {\"delta\":\"hi\"}\n\ndata: [DONE]\n\n")
+            .create_async()
+            .await;
+
+        let runtime = RuntimeConfig::from_credential(ProviderCredential::OAuthBearer {
+            access_token: "codex-token".into(),
+            expires_at: None,
+            id_token: None,
+        });
+        let provider =
+            GenericProvider::from_profile(codex_profile(&server.url()), runtime).unwrap();
+        let request = InferenceRequest::new(
+            "gpt-5.5",
+            Transcript::with_messages(vec![Message::user("hello")]),
+        );
+
+        let stream = provider.infer_stream(request).await.unwrap();
+        let events: Vec<_> = stream.collect().await;
+        mock.assert_async().await;
+
+        assert!(events.iter().any(
+            |event| matches!(event, Ok(ProviderEvent::Output { content }) if content == "hi")
+        ));
+        assert!(events
+            .iter()
+            .any(|event| matches!(event, Ok(ProviderEvent::Complete))));
     }
 }

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -18,10 +18,17 @@ fn build_client(
     runtime: &crate::profile::RuntimeConfig,
 ) -> ProviderResult<Client> {
     let context = format!("profile '{}'", profile.slug);
+    let kind = runtime.credential.kind();
+    let auth_strategy = profile.auth_strategy_for(kind).ok_or_else(|| {
+        ProviderError::auth(format!(
+            "Provider '{}' does not support {:?} credentials",
+            profile.slug, kind
+        ))
+    })?;
     crate::http_client::build_http_client(crate::http_client::HttpClientParams {
         context: &context,
-        api_key: &runtime.api_key,
-        auth_strategy: &profile.auth_strategy,
+        credential: &runtime.credential,
+        auth_strategy,
         default_headers: &profile.default_headers,
         extra_headers: &[],
         connect_timeout: runtime.effective_connect_timeout(),

--- a/src/generic_provider.rs
+++ b/src/generic_provider.rs
@@ -57,6 +57,8 @@ impl GenericProvider {
 
     /// Shared construction logic that builds the HTTP client(s) once.
     fn build(profile: Arc<ProviderProfile>, runtime: RuntimeConfig) -> ProviderResult<Self> {
+        runtime.validate()?;
+
         let context = format!("profile '{}'", profile.slug);
 
         // Validate credential kind is supported by this profile.

--- a/src/generic_provider.rs
+++ b/src/generic_provider.rs
@@ -3,7 +3,7 @@ use crate::provider::{Provider, ProviderFuture};
 use crate::{
     openai::OpenAiConfig,
     profile::{ApiFamily, ProviderProfile, RuntimeConfig, RuntimeConfigSource},
-    InferenceRequest, ProviderEvent, ProviderResult,
+    InferenceRequest, ProviderError, ProviderEvent, ProviderResult,
 };
 use async_openai::{config::OpenAIConfig, Client as OpenAiClient};
 use futures::stream::BoxStream;
@@ -59,10 +59,36 @@ impl GenericProvider {
     fn build(profile: Arc<ProviderProfile>, runtime: RuntimeConfig) -> ProviderResult<Self> {
         let context = format!("profile '{}'", profile.slug);
 
+        // Validate credential kind is supported by this profile.
+        let kind = runtime.credential.kind();
+        let auth_strategy = profile
+            .auth_strategy_for(kind)
+            .ok_or_else(|| {
+                ProviderError::auth(format!(
+                    "Provider '{}' does not support {:?} credentials",
+                    profile.slug, kind
+                ))
+            })?
+            .clone();
+
+        // Validate OAuth expiry.
+        if let crate::profile::ProviderCredential::OAuthBearer {
+            expires_at: Some(exp),
+            ..
+        } = &runtime.credential
+        {
+            if std::time::SystemTime::now() >= *exp {
+                return Err(ProviderError::auth(format!(
+                    "OAuth credential for '{}' has expired",
+                    profile.slug
+                )));
+            }
+        }
+
         let http_client = build_http_client(HttpClientParams {
             context: &context,
-            api_key: &runtime.api_key,
-            auth_strategy: &profile.auth_strategy,
+            credential: &runtime.credential,
+            auth_strategy: &auth_strategy,
             default_headers: &profile.default_headers,
             extra_headers: &[],
             connect_timeout: runtime.effective_connect_timeout(),
@@ -71,7 +97,7 @@ impl GenericProvider {
 
         let openai_client = if profile.family == ApiFamily::OpenAiResponses {
             let config = Self::build_openai_config(&profile, &runtime);
-            let mut openai_config = OpenAIConfig::default().with_api_key(&config.api_key);
+            let mut openai_config = OpenAIConfig::default().with_api_key(config.api_key);
             if let Some(ref base_url) = config.base_url {
                 openai_config = openai_config.with_api_base(base_url);
             }
@@ -97,9 +123,14 @@ impl GenericProvider {
     }
 
     fn build_openai_config(profile: &ProviderProfile, runtime: &RuntimeConfig) -> OpenAiConfig {
-        let mut config = OpenAiConfig::new(runtime.api_key.clone())
+        let mut config = OpenAiConfig::new(runtime.credential.secret().to_string())
             .with_base_url(profile.base_url.clone())
-            .with_auth_strategy(profile.auth_strategy.clone())
+            .with_auth_strategy(
+                profile
+                    .auth_strategy_for(crate::profile::CredentialKind::ApiKey)
+                    .cloned()
+                    .unwrap_or(crate::profile::AuthStrategy::BearerToken),
+            )
             .with_quirks(profile.quirks.clone());
 
         if let Some(timeout) = runtime.connect_timeout {
@@ -140,6 +171,14 @@ impl Provider for GenericProvider {
                 let profile = Arc::clone(&self.profile);
                 Box::pin(async move { crate::anthropic::infer(client, &profile, request).await })
             }
+            ApiFamily::CodexResponses => {
+                let client = self.http_client.clone();
+                let runtime = self.runtime.clone();
+                let profile = Arc::clone(&self.profile);
+                Box::pin(
+                    async move { crate::codex::infer(client, &profile, &runtime, request).await },
+                )
+            }
         }
     }
 
@@ -169,6 +208,14 @@ impl Provider for GenericProvider {
                 Box::pin(
                     async move { crate::anthropic::infer_stream(client, &profile, request).await },
                 )
+            }
+            ApiFamily::CodexResponses => {
+                let client = self.http_client.clone();
+                let runtime = self.runtime.clone();
+                let profile = Arc::clone(&self.profile);
+                Box::pin(async move {
+                    crate::codex::infer_stream(client, &profile, &runtime, request).await
+                })
             }
         }
     }

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -5,7 +5,7 @@
 //! module centralizes that so there is one place to change auth behavior, apply
 //! timeouts, or adjust fail-fast validation.
 
-use crate::profile::AuthStrategy;
+use crate::profile::{AuthStrategy, ProviderCredential};
 use crate::{ProviderError, ProviderResult};
 use reqwest::Client;
 use std::collections::HashMap;
@@ -18,7 +18,7 @@ use std::time::Duration;
 /// `"profile 'zai'"` or `"OpenAI client"`).
 pub(crate) struct HttpClientParams<'a> {
     pub context: &'a str,
-    pub api_key: &'a str,
+    pub credential: &'a ProviderCredential,
     pub auth_strategy: &'a AuthStrategy,
     pub default_headers: &'a HashMap<String, String>,
     pub extra_headers: &'a [(&'a str, &'a str)],
@@ -54,9 +54,10 @@ pub(crate) fn build_http_client(params: HttpClientParams<'_>) -> ProviderResult<
         headers.insert(hk, hv);
     }
 
+    let secret = params.credential.secret();
     match params.auth_strategy {
         AuthStrategy::BearerToken => {
-            let val = reqwest::header::HeaderValue::from_str(&format!("Bearer {}", params.api_key))
+            let val = reqwest::header::HeaderValue::from_str(&format!("Bearer {}", secret))
                 .map_err(|e| {
                     ProviderError::invalid_request(format!(
                         "Invalid bearer token value for {}: {}",
@@ -73,7 +74,7 @@ pub(crate) fn build_http_client(params: HttpClientParams<'_>) -> ProviderResult<
                         header_name, params.context, e
                     ))
                 })?;
-            let val = reqwest::header::HeaderValue::from_str(params.api_key).map_err(|e| {
+            let val = reqwest::header::HeaderValue::from_str(secret).map_err(|e| {
                 ProviderError::invalid_request(format!(
                     "Invalid API key value for {}: {}",
                     params.context, e
@@ -86,8 +87,8 @@ pub(crate) fn build_http_client(params: HttpClientParams<'_>) -> ProviderResult<
             prefix,
         } => {
             let value = match prefix {
-                Some(p) => format!("{} {}", p, params.api_key),
-                None => params.api_key.to_string(),
+                Some(p) => format!("{} {}", p, secret),
+                None => secret.to_string(),
             };
             let key =
                 reqwest::header::HeaderName::from_bytes(header_name.as_bytes()).map_err(|e| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@
 //! [`InferenceRequest`].
 
 pub mod anthropic;
+pub mod codex;
 pub mod completions;
 pub mod error;
 pub mod generic_provider;
@@ -72,8 +73,8 @@ pub use model::{
     Transcript, CHOICE_REQUEST_TOOL_NAME,
 };
 pub use profile::{
-    ApiFamily, AuthStrategy, EndpointPurpose, ProviderProfile, ProviderQuirks, RuntimeConfig,
-    RuntimeConfigSource,
+    ApiFamily, AuthStrategy, CredentialAuthConfig, CredentialKind, EndpointPurpose,
+    ProviderCredential, ProviderProfile, ProviderQuirks, RuntimeConfig, RuntimeConfigSource,
 };
 pub use provider::{OpenAiProvider, Provider, ProviderFuture};
 pub use registry::ProviderRegistry;
@@ -82,10 +83,11 @@ pub use openai::{OpenAiConfig, OpenAiConfigSource};
 
 pub mod prelude {
     pub use crate::{
-        ApiFamily, AuthStrategy, ChoiceItem, ChoiceRequest, ChoiceSelectionMode, EndpointPurpose,
-        GenerationConfig, GenericProvider, InferenceContext, InferenceRequest, Message,
-        OpenAiConfig, OpenAiConfigSource, OpenAiProvider, Provider, ProviderError, ProviderEvent,
-        ProviderProfile, ProviderRegistry, ProviderResult, RuntimeConfig, RuntimeConfigSource,
-        RuntimeRecord, ToolCall, ToolDefinition, ToolPolicy, Transcript, CHOICE_REQUEST_TOOL_NAME,
+        ApiFamily, AuthStrategy, ChoiceItem, ChoiceRequest, ChoiceSelectionMode, CredentialKind,
+        EndpointPurpose, GenerationConfig, GenericProvider, InferenceContext, InferenceRequest,
+        Message, OpenAiConfig, OpenAiConfigSource, OpenAiProvider, Provider, ProviderCredential,
+        ProviderError, ProviderEvent, ProviderProfile, ProviderRegistry, ProviderResult,
+        RuntimeConfig, RuntimeConfigSource, RuntimeRecord, ToolCall, ToolDefinition, ToolPolicy,
+        Transcript, CHOICE_REQUEST_TOOL_NAME,
     };
 }

--- a/src/mock_provider_tests.rs
+++ b/src/mock_provider_tests.rs
@@ -25,10 +25,17 @@ fn build_test_client(
     runtime: &RuntimeConfig,
 ) -> crate::ProviderResult<reqwest::Client> {
     let context = format!("test profile '{}'", profile.slug);
+    let kind = runtime.credential.kind();
+    let auth_strategy = profile.auth_strategy_for(kind).ok_or_else(|| {
+        crate::ProviderError::auth(format!(
+            "Provider '{}' does not support {:?} credentials",
+            profile.slug, kind
+        ))
+    })?;
     build_http_client(HttpClientParams {
         context: &context,
-        api_key: &runtime.api_key,
-        auth_strategy: &profile.auth_strategy,
+        credential: &runtime.credential,
+        auth_strategy,
         default_headers: &profile.default_headers,
         extra_headers: &[],
         connect_timeout: runtime.effective_connect_timeout(),

--- a/src/mock_provider_tests.rs
+++ b/src/mock_provider_tests.rs
@@ -1,9 +1,12 @@
 use crate::{
     anthropic, completions,
     http_client::{build_http_client, HttpClientParams},
-    profile::{ApiFamily, AuthStrategy, ProviderProfile, RuntimeConfig},
+    profile::{
+        ApiFamily, AuthStrategy, CredentialKind, ProviderCredential, ProviderProfile, RuntimeConfig,
+    },
     InferenceRequest, Message, ProviderEvent, ProviderRegistry, Transcript,
 };
+use mockito::Matcher;
 use serde_json::json;
 
 fn completions_profile(slug: &str, base_url: &str) -> ProviderProfile {
@@ -177,6 +180,68 @@ async fn test_anthropic_basic_response() {
     assert!(events.iter().any(
         |e| matches!(e, ProviderEvent::Output { content } if content == "Hello from anthropic")
     ));
+}
+
+#[tokio::test]
+async fn test_kimi_code_api_key_uses_x_api_key_header() {
+    let mut server = mockito::Server::new_async().await;
+
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "kimi-api-key")
+        .match_header("authorization", Matcher::Missing)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(anthropic_response("Hello from Kimi Code"))
+        .create_async()
+        .await;
+
+    let profile = anthropic_profile("kimi-code", &server.url())
+        .with_credential_auth(CredentialKind::OAuthBearer, AuthStrategy::BearerToken);
+    let runtime = RuntimeConfig::new("kimi-api-key");
+    let request = InferenceRequest::new(
+        "kimi-code-model",
+        Transcript::with_messages(vec![Message::user("hi")]),
+    );
+
+    let client = build_test_client(&profile, &runtime).unwrap();
+    let result = anthropic::infer(client, &profile, request).await;
+    mock.assert_async().await;
+
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_kimi_code_oauth_uses_bearer_header() {
+    let mut server = mockito::Server::new_async().await;
+
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("authorization", "Bearer kimi-oauth-token")
+        .match_header("x-api-key", Matcher::Missing)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(anthropic_response("Hello from Kimi Code OAuth"))
+        .create_async()
+        .await;
+
+    let profile = anthropic_profile("kimi-code", &server.url())
+        .with_credential_auth(CredentialKind::OAuthBearer, AuthStrategy::BearerToken);
+    let runtime = RuntimeConfig::from_credential(ProviderCredential::OAuthBearer {
+        access_token: "kimi-oauth-token".into(),
+        expires_at: None,
+        id_token: None,
+    });
+    let request = InferenceRequest::new(
+        "kimi-code-model",
+        Transcript::with_messages(vec![Message::user("hi")]),
+    );
+
+    let client = build_test_client(&profile, &runtime).unwrap();
+    let result = anthropic::infer(client, &profile, request).await;
+    mock.assert_async().await;
+
+    assert!(result.is_ok());
 }
 
 #[tokio::test]

--- a/src/openai.rs
+++ b/src/openai.rs
@@ -148,9 +148,10 @@ pub(crate) fn build_client(config: &OpenAiConfig) -> ProviderResult<Client<OpenA
         .as_ref()
         .unwrap_or(&AuthStrategy::BearerToken);
 
+    let credential = crate::profile::ProviderCredential::ApiKey(config.api_key.clone());
     let http_client = build_http_client(HttpClientParams {
         context: "OpenAI client",
-        api_key: &config.api_key,
+        credential: &credential,
         auth_strategy: strategy,
         default_headers: &config.default_headers,
         extra_headers: &[],

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -16,6 +16,7 @@ pub enum ApiFamily {
     OpenAiResponses,
     OpenAiChatCompletions,
     AnthropicMessages,
+    CodexResponses,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -28,6 +29,52 @@ pub enum AuthStrategy {
         header_name: String,
         prefix: Option<String>,
     },
+}
+
+/// Kind of credential a provider accepts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum CredentialKind {
+    ApiKey,
+    OAuthBearer,
+}
+
+/// Concrete runtime credential supplied to a provider.
+///
+/// Refresh tokens are intentionally not represented here; credential refresh
+/// is owned by consuming layers such as `iron-core` or the application.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ProviderCredential {
+    ApiKey(String),
+    OAuthBearer {
+        access_token: String,
+        expires_at: Option<std::time::SystemTime>,
+        id_token: Option<String>,
+    },
+}
+
+impl ProviderCredential {
+    /// Return the credential kind.
+    pub fn kind(&self) -> CredentialKind {
+        match self {
+            ProviderCredential::ApiKey(_) => CredentialKind::ApiKey,
+            ProviderCredential::OAuthBearer { .. } => CredentialKind::OAuthBearer,
+        }
+    }
+
+    /// Return the raw secret value suitable for placement on the wire.
+    pub fn secret(&self) -> &str {
+        match self {
+            ProviderCredential::ApiKey(v) => v,
+            ProviderCredential::OAuthBearer { access_token, .. } => access_token,
+        }
+    }
+}
+
+/// Maps a supported credential kind to the wire auth strategy used for it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CredentialAuthConfig {
+    pub kind: CredentialKind,
+    pub auth_strategy: AuthStrategy,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -52,7 +99,7 @@ pub struct ProviderProfile {
     pub models_dev_id: Option<String>,
     pub family: ApiFamily,
     pub base_url: String,
-    pub auth_strategy: AuthStrategy,
+    pub credential_auth: Vec<CredentialAuthConfig>,
     #[serde(default)]
     pub default_headers: HashMap<String, String>,
     pub purpose: EndpointPurpose,
@@ -67,16 +114,51 @@ impl ProviderProfile {
             models_dev_id: None,
             family,
             base_url: base_url.into(),
-            auth_strategy: AuthStrategy::BearerToken,
+            credential_auth: vec![CredentialAuthConfig {
+                kind: CredentialKind::ApiKey,
+                auth_strategy: AuthStrategy::BearerToken,
+            }],
             default_headers: HashMap::new(),
             purpose: EndpointPurpose::General,
             quirks: ProviderQuirks::default(),
         }
     }
 
+    /// Convenience builder that sets or replaces the API-key auth config.
+    /// Preserves readability for existing API-key-only built-ins.
     pub fn with_auth(mut self, strategy: AuthStrategy) -> Self {
-        self.auth_strategy = strategy;
+        self.set_credential_auth(CredentialKind::ApiKey, strategy);
         self
+    }
+
+    /// Add or replace the auth config for a specific credential kind.
+    pub fn with_credential_auth(mut self, kind: CredentialKind, strategy: AuthStrategy) -> Self {
+        self.set_credential_auth(kind, strategy);
+        self
+    }
+
+    fn set_credential_auth(&mut self, kind: CredentialKind, strategy: AuthStrategy) {
+        if let Some(existing) = self.credential_auth.iter_mut().find(|c| c.kind == kind) {
+            existing.auth_strategy = strategy;
+        } else {
+            self.credential_auth.push(CredentialAuthConfig {
+                kind,
+                auth_strategy: strategy,
+            });
+        }
+    }
+
+    /// Whether this profile supports the given credential kind.
+    pub fn supports_credential(&self, kind: CredentialKind) -> bool {
+        self.credential_auth.iter().any(|c| c.kind == kind)
+    }
+
+    /// Resolve the wire auth strategy for a given credential kind.
+    pub fn auth_strategy_for(&self, kind: CredentialKind) -> Option<&AuthStrategy> {
+        self.credential_auth
+            .iter()
+            .find(|c| c.kind == kind)
+            .map(|c| &c.auth_strategy)
     }
 
     pub fn with_models_dev_id(mut self, models_dev_id: impl Into<String>) -> Self {
@@ -109,13 +191,14 @@ impl ProviderProfile {
             ApiFamily::OpenAiResponses | ApiFamily::OpenAiChatCompletions => {
                 crate::openai::SYSTEM_PROMPT_FRAGMENT
             }
+            ApiFamily::CodexResponses => crate::openai::SYSTEM_PROMPT_FRAGMENT,
         }
     }
 }
 
 #[derive(Debug, Clone)]
 pub struct RuntimeConfig {
-    pub api_key: String,
+    pub credential: ProviderCredential,
     /// TCP + TLS connect timeout. `None` uses `DEFAULT_CONNECT_TIMEOUT`.
     pub connect_timeout: Option<Duration>,
     /// Inter-chunk read timeout. `None` uses `DEFAULT_READ_TIMEOUT`.
@@ -123,9 +206,15 @@ pub struct RuntimeConfig {
 }
 
 impl RuntimeConfig {
+    /// Convenience constructor for API-key-only callers.
     pub fn new(api_key: impl Into<String>) -> Self {
+        Self::from_credential(ProviderCredential::ApiKey(api_key.into()))
+    }
+
+    /// Construct from an explicit credential.
+    pub fn from_credential(credential: ProviderCredential) -> Self {
         Self {
-            api_key: api_key.into(),
+            credential,
             connect_timeout: None,
             read_timeout: None,
         }
@@ -156,16 +245,141 @@ impl RuntimeConfig {
     }
 
     pub fn validate(&self) -> Result<(), ProviderError> {
-        if self.api_key.trim().is_empty() {
-            return Err(ProviderError::invalid_request(
-                "RuntimeConfig API key is required but was empty",
-            ));
+        match &self.credential {
+            ProviderCredential::ApiKey(key) if key.trim().is_empty() => {
+                Err(ProviderError::auth("API key is required but was empty"))
+            }
+            ProviderCredential::OAuthBearer { access_token, .. }
+                if access_token.trim().is_empty() =>
+            {
+                Err(ProviderError::auth(
+                    "OAuth access token is required but was empty",
+                ))
+            }
+            _ => Ok(()),
         }
-        Ok(())
     }
 }
 
 /// Projection trait for caller-owned config types that can produce a `RuntimeConfig`.
 pub trait RuntimeConfigSource {
     fn to_runtime_config(&self) -> Result<RuntimeConfig, ProviderError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_runtime_config_new_preserves_api_key() {
+        let rt = RuntimeConfig::new("secret-key");
+        assert_eq!(rt.credential.secret(), "secret-key");
+        assert_eq!(rt.credential.kind(), CredentialKind::ApiKey);
+    }
+
+    #[test]
+    fn test_runtime_config_from_credential_api_key() {
+        let rt = RuntimeConfig::from_credential(ProviderCredential::ApiKey("secret".into()));
+        assert_eq!(rt.credential.secret(), "secret");
+    }
+
+    #[test]
+    fn test_runtime_config_from_credential_oauth_bearer() {
+        let rt = RuntimeConfig::from_credential(ProviderCredential::OAuthBearer {
+            access_token: "token".into(),
+            expires_at: None,
+            id_token: None,
+        });
+        assert_eq!(rt.credential.secret(), "token");
+        assert_eq!(rt.credential.kind(), CredentialKind::OAuthBearer);
+    }
+
+    #[test]
+    fn test_runtime_config_validate_blank_api_key() {
+        let rt = RuntimeConfig::new("   ");
+        assert!(rt.validate().is_err());
+    }
+
+    #[test]
+    fn test_runtime_config_validate_blank_oauth_token() {
+        let rt = RuntimeConfig::from_credential(ProviderCredential::OAuthBearer {
+            access_token: "   ".into(),
+            expires_at: None,
+            id_token: None,
+        });
+        assert!(rt.validate().is_err());
+    }
+
+    #[test]
+    fn test_runtime_config_validate_valid_api_key() {
+        let rt = RuntimeConfig::new("valid");
+        assert!(rt.validate().is_ok());
+    }
+
+    #[test]
+    fn test_runtime_config_validate_valid_oauth() {
+        let rt = RuntimeConfig::from_credential(ProviderCredential::OAuthBearer {
+            access_token: "valid".into(),
+            expires_at: None,
+            id_token: None,
+        });
+        assert!(rt.validate().is_ok());
+    }
+
+    #[test]
+    fn test_profile_default_auth_is_api_key_bearer() {
+        let profile = ProviderProfile::new(
+            "test",
+            ApiFamily::OpenAiChatCompletions,
+            "https://example.com",
+        );
+        assert!(profile.supports_credential(CredentialKind::ApiKey));
+        assert!(!profile.supports_credential(CredentialKind::OAuthBearer));
+        assert_eq!(
+            profile.auth_strategy_for(CredentialKind::ApiKey),
+            Some(&AuthStrategy::BearerToken)
+        );
+    }
+
+    #[test]
+    fn test_profile_with_credential_auth() {
+        let profile = ProviderProfile::new(
+            "test",
+            ApiFamily::OpenAiChatCompletions,
+            "https://example.com",
+        )
+        .with_credential_auth(CredentialKind::OAuthBearer, AuthStrategy::BearerToken);
+        assert!(profile.supports_credential(CredentialKind::ApiKey));
+        assert!(profile.supports_credential(CredentialKind::OAuthBearer));
+    }
+
+    #[test]
+    fn test_profile_with_auth_replaces_api_key_config() {
+        let profile =
+            ProviderProfile::new("test", ApiFamily::AnthropicMessages, "https://example.com")
+                .with_auth(AuthStrategy::ApiKeyHeader {
+                    header_name: "x-api-key".into(),
+                });
+        assert_eq!(
+            profile.auth_strategy_for(CredentialKind::ApiKey),
+            Some(&AuthStrategy::ApiKeyHeader {
+                header_name: "x-api-key".into()
+            })
+        );
+    }
+
+    #[test]
+    fn test_provider_credential_kind_and_secret() {
+        let api = ProviderCredential::ApiKey("key".into());
+        assert_eq!(api.kind(), CredentialKind::ApiKey);
+        assert_eq!(api.secret(), "key");
+
+        let oauth = ProviderCredential::OAuthBearer {
+            access_token: "tok".into(),
+            expires_at: None,
+            id_token: None,
+        };
+        assert_eq!(oauth.kind(), CredentialKind::OAuthBearer);
+        assert_eq!(oauth.secret(), "tok");
+    }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,5 +1,8 @@
 use crate::{
-    profile::{ApiFamily, AuthStrategy, EndpointPurpose, ProviderProfile, RuntimeConfig},
+    profile::{
+        ApiFamily, AuthStrategy, CredentialAuthConfig, CredentialKind, EndpointPurpose,
+        ProviderProfile, RuntimeConfig,
+    },
     provider::Provider,
     ProviderError, ProviderResult,
 };
@@ -163,6 +166,7 @@ impl ProviderRegistry {
             .with_auth(AuthStrategy::ApiKeyHeader {
                 header_name: "x-api-key".into(),
             })
+            .with_credential_auth(CredentialKind::OAuthBearer, AuthStrategy::BearerToken)
             .with_purpose(EndpointPurpose::Coding),
         );
 
@@ -184,6 +188,21 @@ impl ProviderRegistry {
             ApiFamily::OpenAiChatCompletions,
             "https://api.requesty.ai/v1",
         ));
+
+        {
+            let mut codex = ProviderProfile::new(
+                "codex",
+                ApiFamily::CodexResponses,
+                "https://chatgpt.com/backend-api/codex",
+            )
+            .with_models_dev_id("openai")
+            .with_purpose(EndpointPurpose::Coding);
+            codex.credential_auth = vec![CredentialAuthConfig {
+                kind: CredentialKind::OAuthBearer,
+                auth_strategy: AuthStrategy::BearerToken,
+            }];
+            self.register(codex);
+        }
     }
 }
 
@@ -198,6 +217,8 @@ impl Default for ProviderRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ProviderCredential;
+    use std::time::SystemTime;
 
     #[test]
     fn test_register_and_get() {
@@ -242,6 +263,7 @@ mod tests {
         assert!(slugs.contains(&"kimi-code"));
         assert!(slugs.contains(&"openrouter"));
         assert!(slugs.contains(&"requesty"));
+        assert!(slugs.contains(&"codex"));
     }
 
     #[test]
@@ -273,10 +295,10 @@ mod tests {
         assert_eq!(kimi_code.slug, "kimi-code");
         assert_eq!(kimi_code.family, ApiFamily::AnthropicMessages);
         assert_eq!(
-            kimi_code.auth_strategy,
-            AuthStrategy::ApiKeyHeader {
+            kimi_code.auth_strategy_for(CredentialKind::ApiKey),
+            Some(&AuthStrategy::ApiKeyHeader {
                 header_name: "x-api-key".into()
-            }
+            })
         );
         assert_eq!(kimi_code.purpose, EndpointPurpose::Coding);
         assert_eq!(zai.slug, "zai");
@@ -387,6 +409,76 @@ mod tests {
                 !fragment.contains("{#"),
                 "fragment should not contain Tera comment delimiter"
             );
+        }
+    }
+
+    #[test]
+    fn test_codex_profile_registered() {
+        let registry = ProviderRegistry::default();
+        let codex = registry.get("codex", RuntimeConfig::new("test-key"));
+        // codex rejects API-key credentials
+        assert!(codex.is_err());
+        if let Err(ref e) = codex {
+            let msg = e.to_string();
+            assert!(msg.contains("codex"));
+            assert!(msg.contains("does not support"));
+        }
+    }
+
+    #[test]
+    fn test_codex_profile_metadata() {
+        let registry = ProviderRegistry::default();
+        let profile = registry
+            .resolve_by_models_dev_id("openai")
+            .expect("codex uses models_dev_id = openai");
+        assert_eq!(profile.slug, "codex");
+        assert_eq!(profile.family, ApiFamily::CodexResponses);
+        assert_eq!(profile.purpose, EndpointPurpose::Coding);
+        assert!(profile.supports_credential(CredentialKind::OAuthBearer));
+        assert!(!profile.supports_credential(CredentialKind::ApiKey));
+    }
+
+    #[test]
+    fn test_kimi_code_supports_both_credentials() {
+        let registry = ProviderRegistry::default();
+        let profile = registry.profiles.get("kimi-code").unwrap();
+        assert!(profile.supports_credential(CredentialKind::ApiKey));
+        assert!(profile.supports_credential(CredentialKind::OAuthBearer));
+    }
+
+    #[test]
+    fn test_kimi_rejects_oauth() {
+        let registry = ProviderRegistry::default();
+        let result = registry.get(
+            "kimi",
+            RuntimeConfig::from_credential(ProviderCredential::OAuthBearer {
+                access_token: "tok".into(),
+                expires_at: None,
+                id_token: None,
+            }),
+        );
+        assert!(result.is_err());
+        if let Err(ref e) = result {
+            let msg = e.to_string();
+            assert!(msg.contains("kimi"));
+            assert!(msg.contains("does not support"));
+        }
+    }
+
+    #[test]
+    fn test_expired_oauth_fails() {
+        let registry = ProviderRegistry::default();
+        let result = registry.get(
+            "codex",
+            RuntimeConfig::from_credential(ProviderCredential::OAuthBearer {
+                access_token: "tok".into(),
+                expires_at: Some(SystemTime::UNIX_EPOCH),
+                id_token: None,
+            }),
+        );
+        assert!(result.is_err());
+        if let Err(ref e) = result {
+            assert!(e.to_string().contains("expired"));
         }
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -466,6 +466,35 @@ mod tests {
     }
 
     #[test]
+    fn test_blank_api_key_fails_during_registry_construction() {
+        let registry = ProviderRegistry::default();
+        let result = registry.get("zai", RuntimeConfig::new("   "));
+        assert!(result.is_err());
+        if let Err(ref e) = result {
+            assert!(e.is_authentication());
+            assert!(e.to_string().contains("API key is required"));
+        }
+    }
+
+    #[test]
+    fn test_blank_oauth_token_fails_during_registry_construction() {
+        let registry = ProviderRegistry::default();
+        let result = registry.get(
+            "codex",
+            RuntimeConfig::from_credential(ProviderCredential::OAuthBearer {
+                access_token: "   ".into(),
+                expires_at: None,
+                id_token: None,
+            }),
+        );
+        assert!(result.is_err());
+        if let Err(ref e) = result {
+            assert!(e.is_authentication());
+            assert!(e.to_string().contains("OAuth access token is required"));
+        }
+    }
+
+    #[test]
     fn test_expired_oauth_fails() {
         let registry = ProviderRegistry::default();
         let result = registry.get(


### PR DESCRIPTION
Add a unified credential model supporting both API keys and OAuth bearer tokens, update provider profiles with per-credential auth metadata, and add the Codex Responses provider.

Changes:
- CredentialKind and ProviderCredential enum (ApiKey, OAuthBearer with access_token, expires_at, id_token)
- RuntimeConfig stores ProviderCredential; RuntimeConfig::from_credential() added
- Profile auth metadata: CredentialAuthConfig replaces single auth_strategy
- Auth validation: blank secrets, unsupported kinds, expired OAuth
- HTTP client refactored to use ProviderCredential
- Kimi Code dual auth: API-key (x-api-key) and OAuth Bearer
- Codex provider: ApiFamily::CodexResponses, raw HTTP, store:false, reasoning, parallel_tool_calls
- JWT claim extraction for chatgpt-account-id
- 104 tests
- README updated

Closes #13