### PR TITLE
Fix Codex ChatGPT account routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,9 +23,9 @@ dependencies = [
 
 [[package]]
 name = "async-openai"
-version = "0.38.1"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d60171eea6e36038af16be8f55a952737a0e45df1338ca4514ac653f8a319e5"
+checksum = "2bb666d696156a8da537278ecb3195806d885edf25a573ce23ceec4dee2b0eee"
 dependencies = [
  "async-openai-macros",
  "base64",
@@ -90,9 +90,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -966,18 +966,18 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/codex.rs
+++ b/src/codex.rs
@@ -27,6 +27,11 @@ pub(crate) fn chatgpt_account_id_from_jwt(id_token: &str) -> Option<String> {
         .and_then(|v| v.as_str().map(String::from))
         .or_else(|| {
             payload
+                .get("https://api.openai.com/auth.chatgpt_account_id")
+                .and_then(|v| v.as_str().map(String::from))
+        })
+        .or_else(|| {
+            payload
                 .get("https://api.openai.com/auth")
                 .and_then(|nested| nested.get("chatgpt_account_id"))
                 .and_then(|v| v.as_str().map(String::from))
@@ -63,10 +68,12 @@ fn build_codex_headers(
     ];
 
     if let ProviderCredential::OAuthBearer {
-        id_token: Some(ref token),
+        access_token,
+        id_token,
         ..
-    } = runtime.credential
+    } = &runtime.credential
     {
+        let token = id_token.as_deref().unwrap_or(access_token);
         if let Some(account_id) = chatgpt_account_id_from_jwt(token) {
             headers.push(("chatgpt-account-id".to_string(), account_id));
         }
@@ -407,6 +414,16 @@ mod tests {
     }
 
     #[test]
+    fn test_jwt_flat_namespaced_account_id() {
+        let payload = r#"{"https://api.openai.com/auth.chatgpt_account_id":"acct_namespaced"}"#;
+        let jwt = fake_jwt(payload);
+        assert_eq!(
+            chatgpt_account_id_from_jwt(&jwt),
+            Some("acct_namespaced".to_string())
+        );
+    }
+
+    #[test]
     fn test_jwt_organization_fallback() {
         let payload = r#"{"organizations":[{"id":"org_789"}]}"#;
         let jwt = fake_jwt(payload);
@@ -479,6 +496,22 @@ mod tests {
         assert!(headers
             .iter()
             .any(|(k, v)| k == "chatgpt-account-id" && v == "acct_abc"));
+    }
+
+    #[test]
+    fn test_build_codex_headers_with_namespaced_account_id_from_access_token() {
+        let access_token = fake_jwt(
+            r#"{"https://api.openai.com/auth.chatgpt_account_id":"acct_from_access"}"#,
+        );
+        let runtime = RuntimeConfig::from_credential(ProviderCredential::OAuthBearer {
+            access_token,
+            expires_at: None,
+            id_token: None,
+        });
+        let headers = build_codex_headers(&runtime, "0.1.8").unwrap();
+        assert!(headers
+            .iter()
+            .any(|(k, v)| k == "chatgpt-account-id" && v == "acct_from_access"));
     }
 
     #[test]

--- a/src/codex.rs
+++ b/src/codex.rs
@@ -500,9 +500,8 @@ mod tests {
 
     #[test]
     fn test_build_codex_headers_with_namespaced_account_id_from_access_token() {
-        let access_token = fake_jwt(
-            r#"{"https://api.openai.com/auth.chatgpt_account_id":"acct_from_access"}"#,
-        );
+        let access_token =
+            fake_jwt(r#"{"https://api.openai.com/auth.chatgpt_account_id":"acct_from_access"}"#);
         let runtime = RuntimeConfig::from_credential(ProviderCredential::OAuthBearer {
             access_token,
             expires_at: None,


### PR DESCRIPTION
## Summary
- Add Codex JWT routing support for the flat ChatGPT account claim `https://api.openai.com/auth.chatgpt_account_id`.
- Allow Codex to derive `chatgpt-account-id` from an access-token JWT payload when no ID token is present.
- Refresh semver-compatible Cargo lockfile dependencies.

## Verification
- `cargo test codex`
- `cargo check`
- `cargo test`

Closes #17