### PR TITLE
[CHORE] Allow [CHORE] PRs to bypass issue reference requirement

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -30,6 +30,11 @@ jobs:
               return;
             }
 
+            if (/^\[CHORE\]/i.test(title)) {
+              core.info("CHORE PR detected — skipping issue reference requirement.");
+              return;
+            }
+
             if (!issuePattern.test(`${title}\n${body}`)) {
               core.setFailed("Pull requests must reference a GitHub issue in the title or body, for example `Closes #123`.");
             }


### PR DESCRIPTION
## Summary

Allows PRs with a `[CHORE]` prefix in the title to bypass the issue-reference validation in the pull-request workflow. Routine maintenance tasks (dependency bumps, typo fixes, config tweaks) no longer need a dedicated issue.

## Changes

- Updated `validate-pr-policy` job in `.github/workflows/pull-request.yml` to detect `[CHORE]` prefix (case-insensitive) and skip the issue-reference check.

Closes #26