### PR TITLE
feat: support upstream-owned provider profiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,9 +79,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bumpalo"
@@ -716,9 +716,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru-slab"
@@ -1094,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -1961,9 +1961,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",

--- a/openspec/changes/support-upstream-owned-provider-profiles/.openspec.yaml
+++ b/openspec/changes/support-upstream-owned-provider-profiles/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-06

--- a/openspec/changes/support-upstream-owned-provider-profiles/design.md
+++ b/openspec/changes/support-upstream-owned-provider-profiles/design.md
@@ -1,0 +1,80 @@
+## Context
+
+`iron-providers` owns built-in provider profile metadata through `ProviderRegistry::register_builtins()`. AgentIron wants to consume those upstream profiles directly, but two gaps currently force app-side profile definitions: direct API-key access to public OpenAI Responses and custom local OpenAI-compatible endpoints.
+
+The current model has a clean separation between static profile metadata and runtime construction state, but `RuntimeConfig` only includes credentials and timeouts. Because `ProviderConnection` reads `profile.base_url` directly, a caller that wants a one-session local endpoint override must clone or redefine the whole `ProviderProfile`, including fields that should stay upstream-owned.
+
+Registry lookup by `models.dev` identity also assumes a one-to-one mapping. Adding a direct `openai` profile while `codex` keeps `models_dev_id = "openai"` turns that into a one-to-many relationship, and the current `HashMap::values().find(...)` lookup cannot provide deterministic selection.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Register a direct `openai` built-in profile for public OpenAI Responses API-key access.
+- Let callers override the effective base URL for a provider connection without redefining the upstream profile.
+- Preserve `local` as the generic upstream-owned local OpenAI-compatible provider profile.
+- Make shared `models.dev` identity resolution deterministic and explicit for consumers.
+- Preserve existing `codex`, `local`, and other built-in behavior unless called through the new capabilities.
+
+**Non-Goals:**
+
+- Do not add a new API family or provider-branded adapter.
+- Do not make every profile field runtime-overridable.
+- Do not move OAuth refresh, model catalog fetching, or user preference ownership into this crate.
+- Do not remove existing slug-based provider lookup.
+
+## Decisions
+
+### Add `openai` as a built-in Responses profile
+
+Register `openai` with `ApiFamily::Responses`, base URL `https://api.openai.com/v1`, API-key Bearer auth, and `models_dev_id = "openai"` unless the slug fallback is sufficient for catalog mapping.
+
+Rationale: AgentIron still exposes `openai` as a first-class provider/default provider. Keeping the public OpenAI protocol metadata upstream avoids app-side profile duplication and aligns with the existing Responses adapter contract.
+
+Alternative considered: Treat `codex` as the only OpenAI-related built-in. That keeps the registry smaller but forces API-key OpenAI consumers to keep defining local protocol metadata.
+
+### Represent base URL override as runtime-effective connection state
+
+Add a small provider-construction option, likely on `RuntimeConfig`, for an optional base URL override. During `ProviderConnection` construction, resolve an effective base URL from `runtime.base_url_override.unwrap_or(profile.base_url)`. API adapters should use the effective base URL rather than directly reading the static profile field for request targets.
+
+Rationale: The override is session-specific, not provider identity. Keeping it out of `ProviderProfile` prevents consumers from redefining API family, auth, credential support, quirks, endpoint purpose, and headers just to change a host or port.
+
+Alternative considered: Add a `ProviderProfile::with_base_url` clone helper. This is smaller, but it still asks consumers to create derived profile definitions and does not clearly distinguish static upstream metadata from runtime selection.
+
+### Keep overrides generic, but document the local use case
+
+The runtime base URL override should be available through the provider construction path rather than a `local`-only method. The primary required behavior is for `local`, but the mechanism does not need to encode provider-specific policy.
+
+Rationale: A generic override keeps the API orthogonal and avoids adding a special registry path that only works for one slug. Tests can still focus on `local` because that is the motivating built-in provider.
+
+Alternative considered: Add `ProviderRegistry::get_local_with_base_url(...)`. This is narrow and safe, but it does not scale if other OpenAI-compatible profiles need session endpoint overrides later.
+
+### Make `models.dev` identity lookup one-to-many
+
+Introduce an API that returns all profiles matching a `models.dev` provider identity in deterministic order, such as slug-sorted order. Existing single-profile lookup can either delegate to the deterministic list and return the first match or be documented as a legacy convenience, but consumers that care about correctness should use the multi-result API.
+
+Rationale: `openai` and `codex` can both legitimately map to the same external catalog provider ID while representing different endpoint/auth/purpose profiles. Returning a list makes that multiplicity visible instead of hiding it behind map iteration order.
+
+Alternative considered: Add a purpose-filtered resolver only. Filtering by `EndpointPurpose` is useful, but it does not fully solve future cases where two profiles share catalog identity and purpose but differ by credential or endpoint behavior.
+
+## Risks / Trade-offs
+
+- Runtime base URL overrides could be used on hosted providers unexpectedly -> validate URL shape and keep the feature explicit through a named builder/API rather than hidden environment behavior.
+- Adding `openai` changes `models.dev` lookup cardinality for `openai` -> provide deterministic multi-result lookup and tests covering both `openai` and `codex`.
+- Storing effective base URL separately from `ProviderProfile` can create two places to look for endpoint state -> expose or document the effective value through `ProviderConnection` tests and keep static profile metadata unchanged.
+- Keeping the old single-result `resolve_by_models_dev_id` may preserve ambiguity -> prefer a new explicit API for consumers and use deterministic behavior if the old API remains.
+
+## Migration Plan
+
+- Add the upstream built-in `openai` profile and tests without removing existing `codex` behavior.
+- Add runtime/provider-construction base URL override support and update request-building internals to use the effective base URL.
+- Add deterministic multi-profile `models.dev` identity resolution and keep existing slug lookup unchanged.
+- AgentIron can then delete its temporary local `openai` and `local` profile definitions and call the upstream registry APIs instead.
+
+Rollback is straightforward because the change adds capabilities. Consumers can continue to construct explicit `ProviderProfile` values if needed.
+
+## Open Questions
+
+- Should the runtime override be limited to absolute HTTP(S) URLs, or should validation remain minimal and defer to request construction?
+- Should the old `resolve_by_models_dev_id` remain public as a deterministic convenience, or should consumers be steered entirely to a new plural API?
+- Should direct `openai` explicitly set `models_dev_id = "openai"`, or rely on the slug fallback for the same effective identity?

--- a/openspec/changes/support-upstream-owned-provider-profiles/proposal.md
+++ b/openspec/changes/support-upstream-owned-provider-profiles/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+AgentIron is moving provider protocol metadata upstream into `iron-providers`, but it still has to define narrow local provider profiles for direct `openai` access and customized `local` base URLs. This duplicates upstream-owned profile metadata and makes profile selection depend on consumer-side workarounds.
+
+## What Changes
+
+- Add upstream support for a direct built-in `openai` provider profile for public OpenAI Responses API-key access, distinct from the OAuth-backed `codex` profile.
+- Add a per-session way to override the effective base URL of the upstream `local` provider without redefining its API family, auth strategies, credential support, quirks, headers, or endpoint purpose.
+- Make registry resolution for shared `models.dev` identities deterministic and explicit enough for consumers to map external catalog provider IDs without relying on `HashMap` iteration order.
+- Preserve existing provider protocol behavior for current built-in slugs, including `codex` OAuth behavior and `local` default endpoint behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `provider-architecture-refactor`: Registry/profile/runtime requirements change to include direct OpenAI profile registration, deterministic shared `models.dev` identity resolution, and runtime-effective provider connection state.
+- `local-model-provider`: Local provider requirements change to support per-session base URL overrides while preserving the upstream built-in profile metadata.
+
+## Impact
+
+- Affected public APIs: `ProviderRegistry`, `RuntimeConfig` or equivalent provider-construction options, and provider-profile lookup helpers.
+- Affected built-ins: `openai`, `codex`, and `local`.
+- Affected internals: provider connection construction, effective base URL selection, registry lookup by `models.dev` identity, and tests for built-in profile metadata.
+- No new external dependencies are expected.

--- a/openspec/changes/support-upstream-owned-provider-profiles/specs/local-model-provider/spec.md
+++ b/openspec/changes/support-upstream-owned-provider-profiles/specs/local-model-provider/spec.md
@@ -1,0 +1,42 @@
+## MODIFIED Requirements
+
+### Requirement: Local provider SHALL work with all OpenAI-compatible backends
+The `local` provider SHALL support connection to any local LLM serving system that exposes an OpenAI-compatible `/v1/chat/completions` endpoint with either no authentication or Bearer API-key authentication. Callers SHALL be able to select a per-session local base URL override without redefining the upstream `local` provider profile.
+
+#### Scenario: LM Studio works with runtime base URL override
+- **WHEN** the `local` provider is constructed with a runtime base URL override of `http://localhost:1234/v1`
+- **THEN** inference requests reach LM Studio's API server
+- **AND** no auth headers are sent when `RuntimeConfig::none()` is used
+- **AND** the upstream `local` profile metadata remains unchanged
+
+#### Scenario: Jan works with runtime base URL override
+- **WHEN** the `local` provider is constructed with a runtime base URL override of `http://localhost:1337/v1`
+- **THEN** inference requests reach Jan's API server
+- **AND** no auth headers are sent when `RuntimeConfig::none()` is used
+- **AND** the upstream `local` profile metadata remains unchanged
+
+#### Scenario: MLX-LM works with runtime base URL override
+- **WHEN** the `local` provider is constructed with a runtime base URL override of `http://localhost:8080/v1`
+- **THEN** inference requests reach MLX-LM's API server
+- **AND** no auth headers are sent when `RuntimeConfig::none()` is used
+- **AND** the upstream `local` profile metadata remains unchanged
+
+#### Scenario: vLLM works with runtime base URL override
+- **WHEN** the `local` provider is constructed with a runtime base URL override of `http://localhost:8000/v1`
+- **THEN** inference requests reach vLLM's API server
+- **AND** no auth headers are sent when `RuntimeConfig::none()` is used
+- **AND** the upstream `local` profile metadata remains unchanged
+
+## ADDED Requirements
+
+### Requirement: Local provider SHALL preserve its upstream default endpoint
+The built-in `local` provider profile SHALL keep its upstream default endpoint for callers that do not supply a per-session base URL override.
+
+#### Scenario: local default endpoint is used without override
+- **WHEN** the `local` provider is constructed without a runtime base URL override
+- **THEN** its requests use `http://localhost:11434/v1` as the base URL
+
+#### Scenario: local profile is not redefined for override
+- **WHEN** the `local` provider is constructed with a runtime base URL override
+- **THEN** the connection uses the override for request URLs
+- **AND** the registered `local` profile still reports `http://localhost:11434/v1` as its base URL

--- a/openspec/changes/support-upstream-owned-provider-profiles/specs/provider-architecture-refactor/spec.md
+++ b/openspec/changes/support-upstream-owned-provider-profiles/specs/provider-architecture-refactor/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Provider registry SHALL include a direct OpenAI Responses provider
+The provider registry SHALL include a built-in `openai` provider profile for public OpenAI Responses API access, distinct from the `codex` provider profile.
+
+#### Scenario: openai slug is registered
+- **WHEN** the default provider registry is constructed
+- **THEN** its slugs include `openai`
+- **AND** its slugs continue to include `codex`
+
+#### Scenario: openai uses Responses API-key access
+- **WHEN** the `openai` profile is examined
+- **THEN** its `family` is `ApiFamily::Responses`
+- **AND** its base URL is `https://api.openai.com/v1`
+- **AND** it supports `CredentialKind::ApiKey`
+- **AND** API-key requests use Bearer token auth
+
+#### Scenario: openai remains distinct from codex
+- **WHEN** the `openai` and `codex` profiles are examined
+- **THEN** `openai` represents public OpenAI API-key access
+- **AND** `codex` represents ChatGPT/Codex OAuth-backed access
+- **AND** adding `openai` does not change `codex` endpoint, auth, fixed body, or header behavior
+
+### Requirement: Provider construction SHALL support runtime-effective base URLs
+Provider construction SHALL support an optional per-session base URL override that changes the effective request base URL without mutating or redefining the upstream `ProviderProfile`.
+
+#### Scenario: runtime base URL override wins for connection requests
+- **WHEN** a provider connection is constructed with a profile and a runtime base URL override
+- **THEN** inference and streaming requests use the override as the request base URL
+- **AND** the static profile base URL remains unchanged
+
+#### Scenario: profile base URL is used without override
+- **WHEN** a provider connection is constructed without a runtime base URL override
+- **THEN** inference and streaming requests use the profile base URL
+
+#### Scenario: runtime override preserves profile-owned metadata
+- **WHEN** a runtime base URL override is supplied
+- **THEN** API family, credential support, auth strategy, default headers, endpoint purpose, quirks, and provider overrides continue to come from the upstream profile
+
+### Requirement: Registry SHALL expose deterministic models.dev identity resolution
+The provider registry SHALL expose deterministic resolution for profiles that share a `models.dev` provider identity.
+
+#### Scenario: shared models.dev identity returns all matching profiles deterministically
+- **WHEN** multiple registered profiles have the same effective `models.dev` provider identity
+- **THEN** registry resolution can return all matching profiles
+- **AND** the returned order is deterministic across runs
+
+#### Scenario: openai catalog identity includes public OpenAI and Codex profiles
+- **WHEN** profiles are resolved for the `models.dev` identity `openai`
+- **THEN** the result includes the direct `openai` profile
+- **AND** the result includes the `codex` profile
+- **AND** consumers can distinguish them by slug, endpoint purpose, credential support, and endpoint metadata
+
+#### Scenario: single-profile lookup does not rely on HashMap iteration order
+- **WHEN** a single-profile `models.dev` lookup API remains available
+- **THEN** its selected result is deterministic
+- **AND** its behavior does not depend on `HashMap` value iteration order

--- a/openspec/changes/support-upstream-owned-provider-profiles/tasks.md
+++ b/openspec/changes/support-upstream-owned-provider-profiles/tasks.md
@@ -1,0 +1,35 @@
+## 1. Runtime-Effective Endpoint Support
+
+- [x] 1.1 Add an optional runtime/provider-construction base URL override API with a named builder or equivalent explicit entry point.
+- [x] 1.2 Resolve an effective base URL during `ProviderConnection` construction without mutating the registered `ProviderProfile`.
+- [x] 1.3 Update Responses, Completions, and Messages request URL construction to use the effective base URL.
+- [x] 1.4 Add tests proving profile base URLs are used when no override is supplied.
+- [x] 1.5 Add tests proving override base URLs are used for requests while static profile metadata remains unchanged.
+
+## 2. Built-In OpenAI Profile
+
+- [x] 2.1 Register a built-in `openai` profile for public OpenAI Responses API access.
+- [x] 2.2 Ensure the `openai` profile uses `ApiFamily::Responses`, `https://api.openai.com/v1`, and API-key Bearer auth.
+- [x] 2.3 Add tests proving `openai` and `codex` are both registered and remain distinct.
+- [x] 2.4 Add tests proving adding `openai` does not change Codex OAuth rejection/acceptance, endpoint, fixed body, or header behavior.
+
+## 3. Deterministic models.dev Resolution
+
+- [x] 3.1 Add a registry API that returns all profiles matching an effective `models.dev` provider identity in deterministic order.
+- [x] 3.2 Make any remaining single-profile `models.dev` resolver deterministic or document/use the plural resolver for ambiguous cases.
+- [x] 3.3 Add tests proving identity `openai` resolves to both `openai` and `codex` through the plural API.
+- [x] 3.4 Add tests proving shared identity resolution order does not depend on `HashMap` iteration order.
+
+## 4. Local Provider Override Behavior
+
+- [x] 4.1 Add tests proving `local` keeps `http://localhost:11434/v1` as its registered default endpoint.
+- [x] 4.2 Add tests proving `local` can target LM Studio-style `http://localhost:1234/v1` through a runtime base URL override.
+- [x] 4.3 Add tests proving `local` override behavior preserves NoAuth and API-key credential behavior.
+- [x] 4.4 Add tests proving the registered `local` profile metadata is unchanged after constructing an overridden connection.
+
+## 5. Documentation and Validation
+
+- [x] 5.1 Update public docs or crate-level examples for direct `openai` and runtime local base URL override usage.
+- [x] 5.2 Run `cargo fmt --manifest-path Cargo.toml -- --check`.
+- [x] 5.3 Run `cargo clippy --manifest-path Cargo.toml --all-targets --all-features -- -D warnings`.
+- [x] 5.4 Run `cargo test --manifest-path Cargo.toml`.

--- a/src/apis/completions.rs
+++ b/src/apis/completions.rs
@@ -392,7 +392,8 @@ fn build_request_body(request: &InferenceRequest, stream: bool) -> serde_json::M
 
 pub(crate) async fn infer(
     client: Client,
-    profile: &ProviderProfile,
+    _profile: &ProviderProfile,
+    effective_base_url: &str,
     request: InferenceRequest,
 ) -> ProviderResult<Vec<ProviderEvent>> {
     request.validate_model()?;
@@ -400,7 +401,7 @@ pub(crate) async fn infer(
 
     let url = format!(
         "{}/chat/completions",
-        profile.base_url.trim_end_matches('/')
+        effective_base_url.trim_end_matches('/')
     );
     let response = client
         .post(&url)
@@ -424,7 +425,8 @@ pub(crate) async fn infer(
 
 pub(crate) async fn infer_stream(
     client: Client,
-    profile: &ProviderProfile,
+    _profile: &ProviderProfile,
+    effective_base_url: &str,
     request: InferenceRequest,
 ) -> ProviderResult<BoxStream<'static, ProviderResult<ProviderEvent>>> {
     request.validate_model()?;
@@ -432,7 +434,7 @@ pub(crate) async fn infer_stream(
 
     let url = format!(
         "{}/chat/completions",
-        profile.base_url.trim_end_matches('/')
+        effective_base_url.trim_end_matches('/')
     );
     let response = client
         .post(&url)

--- a/src/apis/messages.rs
+++ b/src/apis/messages.rs
@@ -245,13 +245,14 @@ fn build_anthropic_request(request: &InferenceRequest, stream: bool) -> Anthropi
 
 pub(crate) async fn infer(
     client: Client,
-    profile: &ProviderProfile,
+    _profile: &ProviderProfile,
+    effective_base_url: &str,
     request: InferenceRequest,
 ) -> ProviderResult<Vec<ProviderEvent>> {
     request.validate_model()?;
     let body = build_anthropic_request(&request, false);
 
-    let url = format!("{}/v1/messages", profile.base_url.trim_end_matches('/'));
+    let url = format!("{}/v1/messages", effective_base_url.trim_end_matches('/'));
     let response = client
         .post(&url)
         .json(&body)
@@ -275,12 +276,13 @@ pub(crate) async fn infer(
 pub(crate) async fn infer_stream(
     client: Client,
     _profile: &ProviderProfile,
+    effective_base_url: &str,
     request: InferenceRequest,
 ) -> ProviderResult<BoxStream<'static, ProviderResult<ProviderEvent>>> {
     request.validate_model()?;
     let body = build_anthropic_request(&request, true);
 
-    let url = format!("{}/v1/messages", _profile.base_url.trim_end_matches('/'));
+    let url = format!("{}/v1/messages", effective_base_url.trim_end_matches('/'));
     let response = client
         .post(&url)
         .json(&body)

--- a/src/apis/responses.rs
+++ b/src/apis/responses.rs
@@ -341,13 +341,14 @@ pub(crate) async fn infer(
     client: Client,
     profile: &ProviderProfile,
     overrides: &ProviderOverrides,
+    effective_base_url: &str,
     request: InferenceRequest,
 ) -> ProviderResult<Vec<ProviderEvent>> {
     request.validate_model()?;
     let body = build_request(&request, overrides, false);
     let path = endpoint_path(profile, overrides);
 
-    let url = format!("{}{}", profile.base_url.trim_end_matches('/'), path);
+    let url = format!("{}{}", effective_base_url.trim_end_matches('/'), path);
     let response = client
         .post(&url)
         .json(&body)
@@ -372,13 +373,14 @@ pub(crate) async fn infer_stream(
     client: Client,
     profile: &ProviderProfile,
     overrides: &ProviderOverrides,
+    effective_base_url: &str,
     request: InferenceRequest,
 ) -> ProviderResult<BoxStream<'static, ProviderResult<ProviderEvent>>> {
     request.validate_model()?;
     let body = build_request(&request, overrides, true);
     let path = endpoint_path(profile, overrides);
 
-    let url = format!("{}{}", profile.base_url.trim_end_matches('/'), path);
+    let url = format!("{}{}", effective_base_url.trim_end_matches('/'), path);
     let response = client
         .post(&url)
         .json(&body)

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -24,6 +24,7 @@ use std::sync::Arc;
 #[derive(Debug, Clone)]
 pub struct ProviderConnection {
     profile: Arc<ProviderProfile>,
+    effective_base_url: String,
     overrides: ProviderOverrides,
     http_client: reqwest::Client,
 }
@@ -94,8 +95,13 @@ impl ProviderConnection {
             runtime.effective_read_timeout(),
         )?;
 
+        let effective_base_url = runtime
+            .base_url_override
+            .unwrap_or_else(|| profile.base_url.clone());
+
         Ok(Self {
             profile,
+            effective_base_url,
             overrides,
             http_client,
         })
@@ -104,6 +110,13 @@ impl ProviderConnection {
     /// Borrow the provider profile.
     pub fn profile(&self) -> &ProviderProfile {
         &self.profile
+    }
+
+    /// The effective base URL used for request targets. When a runtime
+    /// base URL override was supplied during construction, this returns the
+    /// override. Otherwise it returns the profile's default base URL.
+    pub fn effective_base_url(&self) -> &str {
+        &self.effective_base_url
     }
 }
 
@@ -173,17 +186,27 @@ impl Provider for ProviderConnection {
         let client = self.http_client.clone();
         let profile = Arc::clone(&self.profile);
         let overrides = self.overrides.clone();
+        let effective_base_url = self.effective_base_url.clone();
 
         Box::pin(async move {
             match profile.family {
                 ApiFamily::Messages => {
-                    crate::apis::messages::infer(client, &profile, request).await
+                    crate::apis::messages::infer(client, &profile, &effective_base_url, request)
+                        .await
                 }
                 ApiFamily::Completions => {
-                    crate::apis::completions::infer(client, &profile, request).await
+                    crate::apis::completions::infer(client, &profile, &effective_base_url, request)
+                        .await
                 }
                 ApiFamily::Responses => {
-                    crate::apis::responses::infer(client, &profile, &overrides, request).await
+                    crate::apis::responses::infer(
+                        client,
+                        &profile,
+                        &overrides,
+                        &effective_base_url,
+                        request,
+                    )
+                    .await
                 }
             }
         })
@@ -196,18 +219,37 @@ impl Provider for ProviderConnection {
         let client = self.http_client.clone();
         let profile = Arc::clone(&self.profile);
         let overrides = self.overrides.clone();
+        let effective_base_url = self.effective_base_url.clone();
 
         Box::pin(async move {
             match profile.family {
                 ApiFamily::Messages => {
-                    crate::apis::messages::infer_stream(client, &profile, request).await
+                    crate::apis::messages::infer_stream(
+                        client,
+                        &profile,
+                        &effective_base_url,
+                        request,
+                    )
+                    .await
                 }
                 ApiFamily::Completions => {
-                    crate::apis::completions::infer_stream(client, &profile, request).await
+                    crate::apis::completions::infer_stream(
+                        client,
+                        &profile,
+                        &effective_base_url,
+                        request,
+                    )
+                    .await
                 }
                 ApiFamily::Responses => {
-                    crate::apis::responses::infer_stream(client, &profile, &overrides, request)
-                        .await
+                    crate::apis::responses::infer_stream(
+                        client,
+                        &profile,
+                        &overrides,
+                        &effective_base_url,
+                        request,
+                    )
+                    .await
                 }
             }
         })
@@ -313,5 +355,61 @@ mod tests {
         assert!(result.get("authorization").is_none());
         assert!(result.get("x-api-key").is_none());
         assert_eq!(result.get("content-type").unwrap(), "application/json");
+    }
+
+    #[test]
+    fn test_effective_base_url_uses_profile_default() {
+        let profile = crate::profile::ProviderProfile::new(
+            "test",
+            crate::profile::ApiFamily::Completions,
+            "https://api.example.com/v1",
+        );
+        let runtime = crate::profile::RuntimeConfig::new("test-key");
+        let conn = ProviderConnection::from_profile(profile, runtime).unwrap();
+        assert_eq!(conn.effective_base_url(), "https://api.example.com/v1");
+        assert_eq!(conn.profile().base_url, "https://api.example.com/v1");
+    }
+
+    #[test]
+    fn test_effective_base_url_uses_override() {
+        let profile = crate::profile::ProviderProfile::new(
+            "test",
+            crate::profile::ApiFamily::Completions,
+            "https://api.example.com/v1",
+        );
+        let runtime = crate::profile::RuntimeConfig::new("test-key")
+            .with_base_url("http://localhost:1234/v1");
+        let conn = ProviderConnection::from_profile(profile, runtime).unwrap();
+        assert_eq!(conn.effective_base_url(), "http://localhost:1234/v1");
+        assert_eq!(
+            conn.profile().base_url,
+            "https://api.example.com/v1",
+            "static profile metadata must remain unchanged"
+        );
+    }
+
+    #[test]
+    fn test_effective_base_url_preserves_profile_metadata() {
+        let profile = crate::profile::ProviderProfile::new(
+            "test",
+            crate::profile::ApiFamily::Completions,
+            "https://api.example.com/v1",
+        )
+        .with_credential_auth(
+            crate::profile::CredentialKind::NoAuth,
+            crate::profile::AuthStrategy::NoAuth,
+        );
+        let runtime = crate::profile::RuntimeConfig::none().with_base_url("http://custom:9999");
+        let conn = ProviderConnection::from_profile(profile.clone(), runtime).unwrap();
+        assert_eq!(conn.effective_base_url(), "http://custom:9999");
+        assert_eq!(
+            conn.profile().family,
+            crate::profile::ApiFamily::Completions
+        );
+        assert_eq!(conn.profile().slug, "test");
+        assert!(conn
+            .profile()
+            .supports_credential(crate::profile::CredentialKind::NoAuth));
+        assert_eq!(profile.base_url, "https://api.example.com/v1");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,8 @@
 //! - **[`ProviderRegistry`]**: Registry for looking up providers by slug or
 //!   URL pattern, with built-in profiles for common providers. Includes
 //!   `local` for OpenAI-compatible local endpoints (Ollama, LM Studio, etc.)
-//!   via `/v1/chat/completions`, and `ollama-cloud` for the Ollama cloud API.
+//!   via `/v1/chat/completions`, `ollama-cloud` for the Ollama cloud API, and
+//!   `openai` for public OpenAI Responses API-key access.
 //!
 //! # Streaming
 //!

--- a/src/mock_provider_tests.rs
+++ b/src/mock_provider_tests.rs
@@ -153,7 +153,7 @@ async fn test_completions_basic_response() {
     );
 
     let client = build_test_client(&profile, &runtime).unwrap();
-    let result = completions::infer(client, &profile, request).await;
+    let result = completions::infer(client, &profile, &profile.base_url, request).await;
     mock.assert_async().await;
 
     assert!(result.is_ok());
@@ -187,7 +187,7 @@ async fn test_completions_tool_call_response() {
     );
 
     let client = build_test_client(&profile, &runtime).unwrap();
-    let result = completions::infer(client, &profile, request).await;
+    let result = completions::infer(client, &profile, &profile.base_url, request).await;
     mock.assert_async().await;
 
     assert!(result.is_ok());
@@ -217,7 +217,7 @@ async fn test_anthropic_basic_response() {
     );
 
     let client = build_test_client(&profile, &runtime).unwrap();
-    let result = messages::infer(client, &profile, request).await;
+    let result = messages::infer(client, &profile, &profile.base_url, request).await;
     mock.assert_async().await;
 
     assert!(result.is_ok());
@@ -250,7 +250,7 @@ async fn test_kimi_code_api_key_uses_x_api_key_header() {
     );
 
     let client = build_test_client(&profile, &runtime).unwrap();
-    let result = messages::infer(client, &profile, request).await;
+    let result = messages::infer(client, &profile, &profile.base_url, request).await;
     mock.assert_async().await;
 
     assert!(result.is_ok());
@@ -283,7 +283,7 @@ async fn test_kimi_code_oauth_uses_bearer_header() {
     );
 
     let client = build_test_client(&profile, &runtime).unwrap();
-    let result = messages::infer(client, &profile, request).await;
+    let result = messages::infer(client, &profile, &profile.base_url, request).await;
     mock.assert_async().await;
 
     assert!(result.is_ok());
@@ -339,7 +339,7 @@ async fn test_completions_error_handling() {
     );
 
     let client = build_test_client(&profile, &runtime).unwrap();
-    let result = completions::infer(client, &profile, request).await;
+    let result = completions::infer(client, &profile, &profile.base_url, request).await;
     mock.assert_async().await;
 
     assert!(result.is_err());
@@ -366,7 +366,7 @@ async fn test_anthropic_error_handling() {
     );
 
     let client = build_test_client(&profile, &runtime).unwrap();
-    let result = messages::infer(client, &profile, request).await;
+    let result = messages::infer(client, &profile, &profile.base_url, request).await;
     mock.assert_async().await;
 
     assert!(result.is_err());
@@ -398,7 +398,7 @@ async fn test_completions_stream() {
     );
 
     let client = build_test_client(&profile, &runtime).unwrap();
-    let stream = completions::infer_stream(client, &profile, request)
+    let stream = completions::infer_stream(client, &profile, &profile.base_url, request)
         .await
         .unwrap();
     let events: Vec<_> = futures::executor::block_on_stream(stream).collect();
@@ -444,7 +444,7 @@ async fn test_anthropic_stream() {
     );
 
     let client = build_test_client(&profile, &runtime).unwrap();
-    let stream = messages::infer_stream(client, &profile, request)
+    let stream = messages::infer_stream(client, &profile, &profile.base_url, request)
         .await
         .unwrap();
     let events: Vec<_> = futures::executor::block_on_stream(stream).collect();
@@ -510,7 +510,7 @@ async fn test_responses_request_uses_structured_function_items() {
     );
 
     let client = build_test_client(&profile, &runtime).unwrap();
-    let events = responses::infer(client, &profile, &overrides, request)
+    let events = responses::infer(client, &profile, &overrides, &profile.base_url, request)
         .await
         .unwrap();
 
@@ -548,7 +548,7 @@ async fn test_codex_responses_overrides_add_headers_and_fixed_body() {
     );
 
     let client = build_test_client(&profile, &runtime).unwrap();
-    let events = responses::infer(client, &profile, &overrides, request)
+    let events = responses::infer(client, &profile, &overrides, &profile.base_url, request)
         .await
         .unwrap();
 
@@ -587,7 +587,7 @@ async fn test_responses_stream_text_and_tool_call() {
     );
 
     let client = build_test_client(&profile, &runtime).unwrap();
-    let stream = responses::infer_stream(client, &profile, &overrides, request)
+    let stream = responses::infer_stream(client, &profile, &overrides, &profile.base_url, request)
         .await
         .unwrap();
     let events: Vec<_> = futures::executor::block_on_stream(stream).collect();
@@ -640,7 +640,7 @@ async fn test_responses_stream_failed_emits_error_without_complete() {
     );
 
     let client = build_test_client(&profile, &runtime).unwrap();
-    let stream = responses::infer_stream(client, &profile, &overrides, request)
+    let stream = responses::infer_stream(client, &profile, &overrides, &profile.base_url, request)
         .await
         .unwrap();
     let events: Vec<_> = futures::executor::block_on_stream(stream).collect();
@@ -687,7 +687,7 @@ async fn test_completions_stream_tool_call_spans_multiple_chunks() {
     );
 
     let client = build_test_client(&profile, &runtime).unwrap();
-    let stream = completions::infer_stream(client, &profile, request)
+    let stream = completions::infer_stream(client, &profile, &profile.base_url, request)
         .await
         .unwrap();
     let events: Vec<_> = futures::executor::block_on_stream(stream).collect();
@@ -750,7 +750,7 @@ async fn test_completions_stream_multiple_tool_calls_not_merged() {
     );
 
     let client = build_test_client(&profile, &runtime).unwrap();
-    let stream = completions::infer_stream(client, &profile, request)
+    let stream = completions::infer_stream(client, &profile, &profile.base_url, request)
         .await
         .unwrap();
     let events: Vec<_> = futures::executor::block_on_stream(stream).collect();
@@ -810,7 +810,7 @@ async fn test_completions_stream_interleaved_text_and_tool_calls() {
     );
 
     let client = build_test_client(&profile, &runtime).unwrap();
-    let stream = completions::infer_stream(client, &profile, request)
+    let stream = completions::infer_stream(client, &profile, &profile.base_url, request)
         .await
         .unwrap();
     let events: Vec<_> = futures::executor::block_on_stream(stream).collect();
@@ -893,7 +893,7 @@ async fn test_completions_stream_tool_calls_before_complete() {
     );
 
     let client = build_test_client(&profile, &runtime).unwrap();
-    let stream = completions::infer_stream(client, &profile, request)
+    let stream = completions::infer_stream(client, &profile, &profile.base_url, request)
         .await
         .unwrap();
     let events: Vec<_> = futures::executor::block_on_stream(stream).collect();
@@ -952,7 +952,7 @@ async fn test_completions_stream_done_flushes_pending() {
     );
 
     let client = build_test_client(&profile, &runtime).unwrap();
-    let stream = completions::infer_stream(client, &profile, request)
+    let stream = completions::infer_stream(client, &profile, &profile.base_url, request)
         .await
         .unwrap();
     let events: Vec<_> = futures::executor::block_on_stream(stream).collect();
@@ -1019,7 +1019,7 @@ async fn test_completions_stream_delayed_metadata() {
     );
 
     let client = build_test_client(&profile, &runtime).unwrap();
-    let stream = completions::infer_stream(client, &profile, request)
+    let stream = completions::infer_stream(client, &profile, &profile.base_url, request)
         .await
         .unwrap();
     let events: Vec<_> = futures::executor::block_on_stream(stream).collect();
@@ -1066,7 +1066,7 @@ async fn test_completions_stream_missing_metadata_best_effort() {
     );
 
     let client = build_test_client(&profile, &runtime).unwrap();
-    let stream = completions::infer_stream(client, &profile, request)
+    let stream = completions::infer_stream(client, &profile, &profile.base_url, request)
         .await
         .unwrap();
     let events: Vec<_> = futures::executor::block_on_stream(stream).collect();
@@ -1118,7 +1118,7 @@ async fn test_completions_stream_invalid_json_skipped() {
     );
 
     let client = build_test_client(&profile, &runtime).unwrap();
-    let stream = completions::infer_stream(client, &profile, request)
+    let stream = completions::infer_stream(client, &profile, &profile.base_url, request)
         .await
         .unwrap();
     let events: Vec<_> = futures::executor::block_on_stream(stream).collect();
@@ -1163,7 +1163,7 @@ async fn test_completions_stream_empty_done() {
     );
 
     let client = build_test_client(&profile, &runtime).unwrap();
-    let stream = completions::infer_stream(client, &profile, request)
+    let stream = completions::infer_stream(client, &profile, &profile.base_url, request)
         .await
         .unwrap();
     let events: Vec<_> = futures::executor::block_on_stream(stream).collect();
@@ -1201,7 +1201,7 @@ async fn test_anthropic_stream_invalid_json_skipped() {
     );
 
     let client = build_test_client(&profile, &runtime).unwrap();
-    let stream = messages::infer_stream(client, &profile, request)
+    let stream = messages::infer_stream(client, &profile, &profile.base_url, request)
         .await
         .unwrap();
     let events: Vec<_> = futures::executor::block_on_stream(stream).collect();
@@ -1258,7 +1258,7 @@ async fn test_completions_choice_request_tool_call() {
     );
 
     let client = build_test_client(&profile, &runtime).unwrap();
-    let stream = completions::infer_stream(client, &profile, request)
+    let stream = completions::infer_stream(client, &profile, &profile.base_url, request)
         .await
         .unwrap();
     let events: Vec<_> = futures::executor::block_on_stream(stream).collect();

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -205,6 +205,11 @@ pub struct RuntimeConfig {
     pub connect_timeout: Option<Duration>,
     /// Inter-chunk read timeout. `None` uses `DEFAULT_READ_TIMEOUT`.
     pub read_timeout: Option<Duration>,
+    /// Per-session base URL override. When `Some`, the provider connection
+    /// uses this URL instead of the profile's `base_url` for request targets.
+    /// Profile metadata (API family, auth, credentials, quirks, etc.) is
+    /// preserved from the upstream profile.
+    pub base_url_override: Option<String>,
 }
 
 impl RuntimeConfig {
@@ -219,6 +224,7 @@ impl RuntimeConfig {
             credential,
             connect_timeout: None,
             read_timeout: None,
+            base_url_override: None,
         }
     }
 
@@ -227,6 +233,7 @@ impl RuntimeConfig {
             credential: ProviderCredential::NoAuth,
             connect_timeout: None,
             read_timeout: None,
+            base_url_override: None,
         }
     }
 
@@ -241,6 +248,15 @@ impl RuntimeConfig {
     /// hanging indefinitely.
     pub fn with_read_timeout(mut self, timeout: Duration) -> Self {
         self.read_timeout = Some(timeout);
+        self
+    }
+
+    /// Override the effective base URL for this session's provider connection.
+    /// When set, request targets use this URL instead of the profile's
+    /// `base_url`. Profile metadata (API family, auth, credentials, quirks,
+    /// etc.) is preserved from the upstream profile.
+    pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
+        self.base_url_override = Some(url.into());
         self
     }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -71,14 +71,24 @@ impl ProviderRegistry {
     }
 
     pub fn resolve_by_models_dev_id(&self, models_dev_id: &str) -> Option<&ProviderProfile> {
-        self.profiles
+        self.profiles_by_models_dev_id(models_dev_id)
+            .into_iter()
+            .next()
+    }
+
+    pub fn profiles_by_models_dev_id(&self, models_dev_id: &str) -> Vec<&ProviderProfile> {
+        let mut matches: Vec<&ProviderProfile> = self
+            .profiles
             .values()
-            .find(|profile| {
+            .filter(|profile| {
                 profile
                     .models_dev_slug()
                     .eq_ignore_ascii_case(models_dev_id)
             })
             .map(|arc| arc.as_ref())
+            .collect();
+        matches.sort_by_key(|p| &p.slug);
+        matches
     }
 
     pub fn slugs(&self) -> Vec<&str> {
@@ -100,6 +110,12 @@ impl ProviderRegistry {
     }
 
     pub fn register_builtins(&mut self) {
+        self.register(ProviderProfile::new(
+            "openai",
+            ApiFamily::Responses,
+            "https://api.openai.com/v1",
+        ));
+
         self.register(
             ProviderProfile::new(
                 "anthropic",
@@ -280,6 +296,7 @@ mod tests {
         assert!(slugs.contains(&"openrouter"));
         assert!(slugs.contains(&"requesty"));
         assert!(slugs.contains(&"codex"));
+        assert!(slugs.contains(&"openai"));
     }
 
     #[test]
@@ -448,6 +465,161 @@ mod tests {
         assert_eq!(profile.purpose, EndpointPurpose::Coding);
         assert!(profile.supports_credential(CredentialKind::OAuthBearer));
         assert!(!profile.supports_credential(CredentialKind::ApiKey));
+    }
+
+    #[test]
+    fn test_openai_profile_metadata() {
+        let registry = ProviderRegistry::default();
+        let profile = registry.profiles.get("openai").expect("openai");
+        assert_eq!(profile.family, ApiFamily::Responses);
+        assert_eq!(profile.base_url, "https://api.openai.com/v1");
+        assert!(profile.supports_credential(CredentialKind::ApiKey));
+        assert!(!profile.supports_credential(CredentialKind::OAuthBearer));
+        assert_eq!(profile.purpose, EndpointPurpose::General);
+    }
+
+    #[test]
+    fn test_openai_accepts_api_key() {
+        let registry = ProviderRegistry::default();
+        let result = registry.get("openai", RuntimeConfig::new("test-key"));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_openai_and_codex_are_distinct() {
+        let registry = ProviderRegistry::default();
+        let openai = registry.profiles.get("openai").expect("openai");
+        let codex = registry.profiles.get("codex").expect("codex");
+
+        assert_ne!(openai.slug, codex.slug);
+        assert_eq!(openai.base_url, "https://api.openai.com/v1");
+        assert_eq!(codex.base_url, "https://chatgpt.com/backend-api/codex");
+        assert!(openai.supports_credential(CredentialKind::ApiKey));
+        assert!(!codex.supports_credential(CredentialKind::ApiKey));
+        assert!(!openai.supports_credential(CredentialKind::OAuthBearer));
+        assert!(codex.supports_credential(CredentialKind::OAuthBearer));
+        assert_eq!(openai.purpose, EndpointPurpose::General);
+        assert_eq!(codex.purpose, EndpointPurpose::Coding);
+    }
+
+    #[test]
+    fn test_openai_does_not_change_codex_behavior() {
+        let registry = ProviderRegistry::default();
+
+        let codex_api_key = registry.get("codex", RuntimeConfig::new("test-key"));
+        assert!(codex_api_key.is_err());
+        if let Err(ref e) = codex_api_key {
+            assert!(e.to_string().contains("does not support"));
+        }
+
+        let codex = registry.profiles.get("codex").expect("codex");
+        assert_eq!(codex.base_url, "https://chatgpt.com/backend-api/codex");
+        assert!(codex.supports_credential(CredentialKind::OAuthBearer));
+        assert!(!codex.supports_credential(CredentialKind::ApiKey));
+    }
+
+    #[test]
+    fn test_profiles_by_models_dev_id_returns_both_openai_profiles() {
+        let registry = ProviderRegistry::default();
+        let profiles = registry.profiles_by_models_dev_id("openai");
+        assert!(profiles.len() >= 2, "should have at least openai and codex");
+        let slugs: Vec<&str> = profiles.iter().map(|p| p.slug.as_str()).collect();
+        assert!(slugs.contains(&"codex"));
+        assert!(slugs.contains(&"openai"));
+    }
+
+    #[test]
+    fn test_profiles_by_models_dev_id_returns_sorted() {
+        let registry = ProviderRegistry::default();
+        let profiles = registry.profiles_by_models_dev_id("openai");
+        let slugs: Vec<&str> = profiles.iter().map(|p| p.slug.as_str()).collect();
+        let mut sorted = slugs.clone();
+        sorted.sort();
+        assert_eq!(slugs, sorted, "profiles should be sorted by slug");
+    }
+
+    #[test]
+    fn test_resolve_by_models_dev_id_is_deterministic() {
+        let registry = ProviderRegistry::default();
+        let first = registry.resolve_by_models_dev_id("openai");
+        let second = registry.resolve_by_models_dev_id("openai");
+        assert_eq!(
+            first.map(|p| p.slug.as_str()),
+            second.map(|p| p.slug.as_str()),
+            "repeated calls must return the same profile"
+        );
+    }
+
+    #[test]
+    fn test_profiles_by_models_dev_id_deterministic_order() {
+        let registry = ProviderRegistry::default();
+        let run1: Vec<&str> = registry
+            .profiles_by_models_dev_id("openai")
+            .iter()
+            .map(|p| p.slug.as_str())
+            .collect();
+        let run2: Vec<&str> = registry
+            .profiles_by_models_dev_id("openai")
+            .iter()
+            .map(|p| p.slug.as_str())
+            .collect();
+        assert_eq!(run1, run2, "order must be deterministic across calls");
+    }
+
+    #[test]
+    fn test_local_default_endpoint_unchanged() {
+        let registry = ProviderRegistry::default();
+        let profile = registry.profiles.get("local").unwrap();
+        assert_eq!(profile.base_url, "http://localhost:11434/v1");
+    }
+
+    #[test]
+    fn test_local_with_base_url_override() {
+        let registry = ProviderRegistry::default();
+        let profile = registry.profiles.get("local").unwrap().as_ref().clone();
+        let runtime = RuntimeConfig::none().with_base_url("http://localhost:1234/v1");
+        let conn =
+            crate::connection::ProviderConnection::from_profile(profile.clone(), runtime).unwrap();
+        assert_eq!(conn.effective_base_url(), "http://localhost:1234/v1");
+        assert_eq!(profile.base_url, "http://localhost:11434/v1");
+    }
+
+    #[test]
+    fn test_local_override_preserves_noauth() {
+        let registry = ProviderRegistry::default();
+        let profile = registry.profiles.get("local").unwrap().as_ref().clone();
+        let runtime = RuntimeConfig::none().with_base_url("http://localhost:9999/v1");
+        let conn =
+            crate::connection::ProviderConnection::from_profile(profile.clone(), runtime).unwrap();
+        assert_eq!(conn.effective_base_url(), "http://localhost:9999/v1");
+        assert!(profile.supports_credential(CredentialKind::NoAuth));
+        assert!(profile.supports_credential(CredentialKind::ApiKey));
+        assert_eq!(profile.family, ApiFamily::Completions);
+    }
+
+    #[test]
+    fn test_local_override_preserves_api_key() {
+        let registry = ProviderRegistry::default();
+        let profile = registry.profiles.get("local").unwrap().as_ref().clone();
+        let runtime = RuntimeConfig::new("my-token").with_base_url("http://localhost:5555");
+        let conn =
+            crate::connection::ProviderConnection::from_profile(profile.clone(), runtime).unwrap();
+        assert_eq!(conn.effective_base_url(), "http://localhost:5555");
+        assert_eq!(profile.base_url, "http://localhost:11434/v1");
+    }
+
+    #[test]
+    fn test_local_registered_profile_unchanged_after_override() {
+        let registry = ProviderRegistry::default();
+        let profile_before = registry.profiles.get("local").unwrap().as_ref().clone();
+        let runtime = RuntimeConfig::none().with_base_url("http://custom:8080");
+        let _conn =
+            crate::connection::ProviderConnection::from_profile(profile_before.clone(), runtime)
+                .unwrap();
+        assert_eq!(profile_before.base_url, "http://localhost:11434/v1");
+        assert_eq!(profile_before.family, ApiFamily::Completions);
+        assert!(profile_before.supports_credential(CredentialKind::NoAuth));
+        assert!(profile_before.supports_credential(CredentialKind::ApiKey));
     }
 
     #[test]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -71,9 +71,12 @@ impl ProviderRegistry {
     }
 
     pub fn resolve_by_models_dev_id(&self, models_dev_id: &str) -> Option<&ProviderProfile> {
-        self.profiles_by_models_dev_id(models_dev_id)
-            .into_iter()
-            .next()
+        let matches = self.profiles_by_models_dev_id(models_dev_id);
+        matches
+            .iter()
+            .copied()
+            .find(|p| p.slug.eq_ignore_ascii_case(models_dev_id))
+            .or_else(|| matches.into_iter().next())
     }
 
     pub fn profiles_by_models_dev_id(&self, models_dev_id: &str) -> Vec<&ProviderProfile> {
@@ -457,9 +460,7 @@ mod tests {
     #[test]
     fn test_codex_profile_metadata() {
         let registry = ProviderRegistry::default();
-        let profile = registry
-            .resolve_by_models_dev_id("openai")
-            .expect("codex uses models_dev_id = openai");
+        let profile = registry.profiles.get("codex").expect("codex profile");
         assert_eq!(profile.slug, "codex");
         assert_eq!(profile.family, ApiFamily::Responses);
         assert_eq!(profile.purpose, EndpointPurpose::Coding);


### PR DESCRIPTION
## Summary
- add built-in public OpenAI Responses provider profile
- add runtime base URL override support while preserving upstream profile metadata
- expose deterministic models.dev profile resolution for shared catalog identities
- update Cargo.lock transitive dependencies

Closes #25

## Validation
- cargo fmt --manifest-path Cargo.toml -- --check
- cargo clippy --manifest-path Cargo.toml --all-targets --all-features -- -D warnings
- cargo test --manifest-path Cargo.toml
- cargo audit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Built-in OpenAI provider profile for direct API-key access
  * Per-session endpoint/base-URL override to redirect requests without changing provider metadata
  * Deterministic provider resolution when multiple profiles share the same identity
  * Local provider extended to support additional OpenAI-compatible backends

* **Documentation**
  * Added design, proposal, spec, and task docs describing the new behaviors

* **Tests**
  * Expanded tests to cover overrides, resolution determinism, and new profile behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->