### PR TITLE
fix: update ollama-cloud base URL to ollama.com/v1

### DIFF
--- a/openspec/specs/ollama-cloud-integration/spec.md
+++ b/openspec/specs/ollama-cloud-integration/spec.md
@@ -18,7 +18,7 @@ The provider registry SHALL include a built-in `ollama-cloud` provider profile t
 #### Scenario: ollama-cloud uses Completions API family
 - **WHEN** the `ollama-cloud` profile is examined
 - **THEN** its `family` is `ApiFamily::Completions`
-- **AND** its `base_url` is `https://api.ollama.cloud`
+- **AND** its `base_url` is `https://ollama.com/v1`
 
 #### Scenario: ollama-cloud uses BearerToken auth
 - **WHEN** a runtime config is supplied for `ollama-cloud`

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -222,7 +222,7 @@ impl ProviderRegistry {
         self.register(ProviderProfile::new(
             "ollama-cloud",
             ApiFamily::Completions,
-            "https://api.ollama.cloud",
+            "https://ollama.com/v1",
         ));
 
         {
@@ -702,7 +702,7 @@ mod tests {
         let registry = ProviderRegistry::default();
         let profile = registry.profiles.get("ollama-cloud").unwrap();
         assert_eq!(profile.family, ApiFamily::Completions);
-        assert_eq!(profile.base_url, "https://api.ollama.cloud");
+        assert_eq!(profile.base_url, "https://ollama.com/v1");
         assert!(profile.supports_credential(CredentialKind::ApiKey));
     }
 


### PR DESCRIPTION
The hosted Ollama Cloud OpenAI-compatible endpoint is served from `https://ollama.com/v1`, not `https://api.ollama.cloud`. This aligns the built-in `ollama-cloud` profile with the actual API location so requests stop returning 404.

- Updates `src/registry.rs` to register `ollama-cloud` with `https://ollama.com/v1`
- Updates the corresponding registry test
- Syncs the canonical OpenSpec spec\n
Validation run locally:
- `cargo fmt` clean
- `cargo clippy` clean
- `cargo test` 170 tests passed
- `cargo test ollama_cloud` 2 tests passed